### PR TITLE
Mapping/routing mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: stud
 
 stud: stud.c ringbuffer.c ringbuffer.h
-	gcc -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -I/usr/include/libev -I/usr/local/include -L/usr/local/lib -I. -o stud ringbuffer.c stud.c -D_GNU_SOURCE -lssl -lcrypto -lev
+	gcc -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -I/usr/include/libev -I/usr/local/include -L/usr/local/lib -I. -o stud ringbuffer.c stud.c -D_GNU_SOURCE -lssl -lcrypto -lev -lm -ldl
 
 # The -shared targets use shared memory between child processes
 # for the SSL session cache--potentially a huge performance gain

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Detail about the entire set of options can be found by invoking `stud -h`:
     Socket:
       -b HOST,PORT             backend [connect] (default is "127.0.0.1,8000")
       -f HOST,PORT             frontend [bind] (default is "*,8443")
+      -m FHOST,FPORT,BHOST,BPORT[,"ip"|"proxy"]     mapping mode (up to 16 mappings)
 
     Performance:
       -n CORES                 number of worker processes (default is 1)
@@ -146,3 +147,4 @@ Contributors:
     * Joe Williams                  -- Syslog support
     * Jason Cook                    -- SSL option tweaks (performance)
     * Artur Bergman                 -- Socket tweaks (performance)
+    * P-Yves Kerembellec @pyke369   -- mapping/routing mode (feature)


### PR DESCRIPTION
Hi,

I added a "mapping/routing" mode to stud by enabling multiple front/back/options
tuples within the same running instance. I didn't change the logic of stud itself and
tried to adhere to the existing coding style as much as possible (especially the
uppercase configuration variables ^_^).

With this patch, it's now possible to bind multiples distinct front IP/ports and divert
the backend connections to different regular HTTP servers (say on HAProxy instance
with the WRITE_PROXY_LINE option activated, and one Varnish instance without any
extra option).

The old -f/-b option works as before (they are overrided by the first use of the -m
option on the command line).

Cheers,
Pierre-Yves
