### PR TITLE
Fixed mismatching behavior for -q parameter

### DIFF
--- a/stud.c
+++ b/stud.c
@@ -891,7 +891,7 @@ static void parse_cli(int argc, char **argv) {
 
     while (1) {
         int option_index = 0;
-        c = getopt_long(argc, argv, "hf:b:n:c:u:r:B:C:q:s",
+        c = getopt_long(argc, argv, "hf:b:n:c:u:r:B:C:qs",
                 long_options, &option_index);
 
         if (c == -1)


### PR DESCRIPTION
In the stdout instructions, -q is specified to have no parameters (i.e. simply specifying -q is enough to silence the output). In the code, the options string however has "q:" causing entering "-q" by itself to return an error. Unified it to -q with no parameters.
