### PR TITLE
Support of memcached

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # [g]make USE_xxxx=1
 #
 # USE_SHARED_CACHE   :   enable/disable a shared session cache (disabled by default)
+# USE_MEMCACHED      :   enable/disable session sharing with memcached (disabled by default)
 
 DESTDIR =
 PREFIX  = /usr/local
@@ -12,6 +13,13 @@ LDFLAGS = -lssl -lcrypto -lev
 OBJS    = stud.o ringbuffer.o
 
 all: realall
+
+# Memcached
+ifneq ($(USE_MEMCACHED),)
+USE_SHARED_CACHE = 1
+CFLAGS  += -DUSE_MEMCACHED
+LDFLAGS += -lmemcached
+endif
 
 # Shared cache feature
 ifneq ($(USE_SHARED_CACHE),)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ connected client.
 Thanks to a contribution from Emeric at Exceliance (the folks behind HAProxy),
 a special build of `stud` can be made that utilitizes shared memory to
 use a common session cache between all child processes.  This can speed up
-large `stud` deployments by avoiding client renegotiation.
+large `stud` deployments by avoiding client renegotiation. `stud` can
+also be built with memcached support to share the session cache
+between several hosts. Keep in mind this support is somewhat
+experimental and hinders performances.
 
 Releases
 ---------

--- a/stud.8
+++ b/stud.8
@@ -40,6 +40,7 @@
 .Op Fl n Ar cores
 .Op Fl B Ar backlog
 .Op Fl C Ar cache
+.Op Fl M Ar memcache
 .Op Fl r Ar path
 .Op Fl u Ar username
 .Op Fl qs
@@ -90,6 +91,11 @@ worker processes. Default is 1.
 Set listen backlog size. Default is 100.
 .It Fl C Ar cache
 Set shared cache size in sessions. By default, no shared cache is used.
+.It Fl M Ar memcache
+Store and retrieve sessions from memcached if they are not available
+in the local cache. This option cannot be used without a local cache.
+.Ar memcache
+is a string defining the list of memcached servers to use.
 .It Fl r Ar path
 Chroot to the given path. By default, no chroot is done.
 .It Fl u Ar username

--- a/stud.h
+++ b/stud.h
@@ -1,0 +1,80 @@
+/**
+  * Copyright 2011 Bump Technologies, Inc. All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without modification, are
+  * permitted provided that the following conditions are met:
+  *
+  *    1. Redistributions of source code must retain the above copyright notice, this list of
+  *       conditions and the following disclaimer.
+  *
+  *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+  *       of conditions and the following disclaimer in the documentation and/or other materials
+  *       provided with the distribution.
+  *
+  * THIS SOFTWARE IS PROVIDED BY BUMP TECHNOLOGIES, INC. ``AS IS'' AND ANY EXPRESS OR IMPLIED
+  * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BUMP TECHNOLOGIES, INC. OR
+  * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  * The views and conclusions contained in the software and documentation are those of the
+  * authors and should not be interpreted as representing official policies, either expressed
+  * or implied, of Bump Technologies, Inc.
+  *
+  **/
+
+#ifndef STUD_H
+#define STUD_H
+
+#include <syslog.h>
+
+/* Command line Options */
+typedef enum {
+    ENC_TLS,
+    ENC_SSL
+} ENC_TYPE;
+
+typedef struct stud_options {
+    ENC_TYPE ETYPE;
+    int WRITE_IP_OCTET;
+    int WRITE_PROXY_LINE;
+    const char* CHROOT;
+    uid_t UID;
+    gid_t GID;
+    const char *FRONT_IP;
+    const char *FRONT_PORT;
+    const char *BACK_IP;
+    const char *BACK_PORT;
+    long NCORES;
+    const char *CERT_FILE;
+    const char *CIPHER_SUITE;
+    int BACKLOG;
+#ifdef USE_SHARED_CACHE
+    int SHARED_CACHE;
+#ifdef USE_MEMCACHED
+    const char *MEMCACHED;
+#endif /* USE_MEMCACHED */
+#endif /* USE_SHARED_CACHE */
+    int QUIET;
+    int SYSLOG;
+} stud_options;
+
+extern stud_options OPTIONS;
+
+#define LOG(...)                                        \
+    do {                                                \
+      if (!OPTIONS.QUIET) fprintf(stdout, __VA_ARGS__); \
+      if (OPTIONS.SYSLOG) syslog(LOG_INFO, __VA_ARGS__);                    \
+    } while(0)
+
+#define ERR(...)                    \
+    do {                            \
+      fprintf(stderr, __VA_ARGS__); \
+      if (OPTIONS.SYSLOG) syslog(LOG_ERR, __VA_ARGS__); \
+    } while(0)
+
+#endif


### PR DESCRIPTION
Hi!

Here is a way to share sessions between different hosts using memcached. There are two major drawbacks:
1. There seems to be a memory leak (with libmemcached 0.44) but I am not able to pinpoint it. I don't see where it could happen.
2. Storing a new session is done asynchronously. However, getting a session from memcached is done synchronously. Therefore, there is a major performance drawback. Unfortunately, there is no way to register an asynchronous callback with OpenSSL. Either we could use some threads (eeek) or insert remote sessions into the local cache. I don't know if memcached allows something like this. We may switch to something that would broadcast insertions to all stud instances.

So, this is just a proof of concept.
