### PR TITLE
Fix crash from un-initialized ev_io struct.

### DIFF
--- a/stud.c
+++ b/stud.c
@@ -892,7 +892,7 @@ static void parse_cli(int argc, char **argv) {
 
     while (1) {
         int option_index = 0;
-        c = getopt_long(argc, argv, "hf:b:n:c:u:r:B:C:q:s",
+        c = getopt_long(argc, argv, "hf:b:n:c:u:r:B:C:qs",
                 long_options, &option_index);
 
         if (c == -1)


### PR DESCRIPTION
This request fixes a crash that happens when the proxy state is shutdown before the backend connection has connected.

Also fixes the -q option, it doesn't take a argument.
