### PR TITLE
Fix memory leak using shared cache:

### DIFF
--- a/shctx.c
+++ b/shctx.c
@@ -197,7 +197,7 @@ int shctx_new_cb(SSL *ssl, SSL_SESSION *sess) {
 
 	shared_context_unlock();
 
-	return 1; /* leave the session in local cache for reuse */
+	return 0; /* do not increment session reference count */
 }
 
 /* SSL callback used on lookup an existing session cause none found in internal cache */


### PR DESCRIPTION
I detect memory leak during benchmark. I was wrong on a callback return cause openssl online documentation is not up to date.

This leak exists on all previous version of shared cache.

Emeric
