### PR TITLE
Build fails with new Makefile on Ubuntu 11.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ALL += stud
 realall: $(ALL)
 
 stud: $(OBJS)
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 install: $(ALL)
 	install -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
The Makefile recently changed from using this compile statement:

```
gcc -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -I/usr/include/libev -I/usr/local/include -L/usr/local/lib -I. -o stud ringbuffer.c
```

 stud.c -D_GNU_SOURCE -lssl -lcrypto -lev

to using this one:

```
cc -lssl -lcrypto -lev -o stud stud.o ringbuffer.o
```

On Ubuntu 11.10 this generates a slew of errors such as this:

> stud.o: In function `shutdown_proxy':
> /root/downloads/bumptech-stud-976c3a9/stud.c:439: undefined reference to`ev_io_stop'
> /root/downloads/bumptech-stud-976c3a9/stud.c:440: undefined reference to `ev_io_stop'
> /root/downloads/bumptech-stud-976c3a9/stud.c:441: undefined reference to`ev_io_stop'
> /root/downloads/bumptech-stud-976c3a9/stud.c:442: undefined reference to `ev_io_stop'
> /root/downloads/bumptech-stud-976c3a9/stud.c:443: undefined reference to`ev_io_stop'
> stud.o:/root/downloads/bumptech-stud-976c3a9/stud.c:444: more undefined references to `ev_io_stop' follow
> stud.o: In function`shutdown_proxy':
> /root/downloads/bumptech-stud-976c3a9/stud.c:449: undefined reference to `SSL_set_shutdown'
> /root/downloads/bumptech-stud-976c3a9/stud.c:450: undefined reference to`SSL_free'
> stud.o: In function `handle_accept':
> /root/downloads/bumptech-stud-976c3a9/stud.c:822: undefined reference to`SSL_new'
> /root/downloads/bumptech-stud-976c3a9/stud.c:827: undefined reference to `SSL_ctrl'
> /root/downloads/bumptech-stud-976c3a9/stud.c:828: undefined reference to`SSL_set_accept_state'
> /root/downloads/bumptech-stud-976c3a9/stud.c:829: undefined reference to `SSL_set_fd'
> /root/downloads/bumptech-stud-976c3a9/stud.c:853: undefined reference to`ev_io_start'
> /root/downloads/bumptech-stud-976c3a9/stud.c:863: undefined reference to `SSL_set_ex_data'
> stud.o: In function`info_callback':
> /root/downloads/bumptech-stud-976c3a9/stud.c:252: undefined reference to `SSL_get_ex_data'
> stud.o: In function`safe_enable_io':
> /root/downloads/bumptech-stud-976c3a9/stud.c:432: undefined reference to `ev_io_start'
> stud.o: In function`client_handshake':
> /root/downloads/bumptech-stud-976c3a9/stud.c:656: undefined reference to `SSL_do_handshake'
> /root/downloads/bumptech-stud-976c3a9/stud.c:661: undefined reference to`SSL_get_error'
> stud.o: In function `end_handshake':
> /root/downloads/bumptech-stud-976c3a9/stud.c:629: undefined reference to`ev_io_stop'
> /root/downloads/bumptech-stud-976c3a9/stud.c:630: undefined reference to `ev_io_stop'

When I replace the new Makefile with the old Makefile the build works correctly.
