### PR TITLE
Added configuration file support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-conf*
+conf
 ebtree*
+core
+core.*
+*.o
+stud

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MANDIR  = $(PREFIX)/share/man
 
 CFLAGS  = -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -D_GNU_SOURCE
 LDFLAGS = -lssl -lcrypto -lev
-OBJS    = stud.o ringbuffer.o
+OBJS    = stud.o ringbuffer.o configuration.o
 
 all: realall
 
@@ -26,6 +26,11 @@ ebtree:
 		echo "*** Download libebtree at http://1wt.eu/tools/ebtree/" ; \
 		echo "*** Untar it and make a link named 'ebtree' to point on it"; \
 		exit 1 )
+endif
+
+# No config file support?
+ifneq ($(NO_CONFIG_FILE),)
+CFLAGS += -DNO_CONFIG_FILE
 endif
 
 ALL += stud

--- a/configuration.c
+++ b/configuration.c
@@ -1,0 +1,1178 @@
+/**
+ * configuration.c
+ *
+ * Author: Brane F. Gracnar
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <grp.h>
+#include <sys/stat.h>
+
+#include "configuration.h"
+#include "version.h"
+
+#define ADDR_LEN 150
+#define PORT_LEN 6
+#define CFG_BOOL_ON "on"
+
+// BEGIN: configuration parameters
+#define CFG_CIPHERS "ciphers"
+#define CFG_SSL_ENGINE "ssl-engine"
+#define CFG_PREFER_SERVER_CIPHERS "prefer-server-ciphers"
+#define CFG_BACKEND "backend"
+#define CFG_FRONTEND "frontend"
+#define CFG_WORKERS "workers"
+#define CFG_BACKLOG "backlog"
+#define CFG_KEEPALIVE "keepalive"
+#define CFG_CHROOT "chroot"
+#define CFG_USER "user"
+#define CFG_GROUP "group"
+#define CFG_QUIET "quiet"
+#define CFG_SYSLOG "syslog"
+#define CFG_DAEMON "daemon"
+#define CFG_WRITE_IP "write-ip"
+#define CFG_WRITE_PROXY "write-proxy"
+#define CFG_PEM_FILE "pem-file"
+
+#ifdef USE_SHARED_CACHE
+  #define CFG_SHARED_CACHE "shared-cache"
+  #define CFG_SHARED_CACHE_LISTEN "shared-cache-listen"
+  #define CFG_SHARED_CACHE_PEER "shared-cache-peer"
+  #define CFG_SHARED_CACHE_MCASTIF "shared-cache-if"
+#endif
+
+#ifndef NO_CONFIG_FILE
+  #define FMT_STR "%s = %s\n"
+  #define FMT_QSTR "%s = \"%s\"\n"
+  #define FMT_ISTR "%s = %d\n"
+  
+  #define CONFIG_MAX_LINES 10000
+  #define CONFIG_BUF_SIZE 1024
+  #define CFG_PARAM_CFGFILE 10000
+  #define CFG_PARAM_DEFCFG 10001
+
+  #define CFG_CONFIG "config"
+  #define CFG_CONFIG_DEFAULT "default-config"
+#endif
+// END: configuration parameters
+
+static char var_buf[CONFIG_BUF_SIZE];
+static char val_buf[CONFIG_BUF_SIZE];
+static char error_buf[CONFIG_BUF_SIZE];
+static char tmp_buf[150];
+
+// for testing configuration only
+SSL_CTX * init_openssl();
+
+static void config_error_set (char *fmt, ...) {
+  memset(error_buf, '\0', sizeof(error_buf));
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(error_buf, (sizeof(error_buf) - 1), fmt, args);
+  va_end(args);
+}
+
+char * config_error_get (void) {
+  return error_buf;
+}
+
+void config_die (char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+  fprintf(stderr, "\n");
+
+  exit(1);
+}
+
+stud_config * config_new (void) {
+  stud_config *r = NULL;
+  r = malloc(sizeof(stud_config));
+  if (r == NULL) {
+    config_error_set("Unable to allocate memory for configuration structure: %s", strerror(errno));
+    return NULL;
+  }
+  
+  // set default values
+
+  r->ETYPE              = ENC_TLS;
+  r->WRITE_IP_OCTET     = 0;
+  r->WRITE_PROXY_LINE   = 0;
+  r->CHROOT             = NULL;
+  r->UID                = 0;
+  r->GID                = 0;
+  r->FRONT_IP           = NULL;
+  r->FRONT_PORT         = strdup("8443");
+  r->BACK_IP            = strdup("127.0.0.1");
+  r->BACK_PORT          = strdup("8000");
+  r->NCORES             = 1;
+  r->CERT_FILE          = NULL;
+  r->CIPHER_SUITE       = NULL;
+  r->ENGINE             = NULL;
+  r->BACKLOG            = 100;
+
+#ifdef USE_SHARED_CACHE
+  r->SHARED_CACHE       = 0;
+  r->SHCUPD_IP          = NULL;
+  r->SHCUPD_PORT        = NULL;
+  
+  for (int i = 0 ; i < MAX_SHCUPD_PEERS; i++)
+    memset(&r->SHCUPD_PEERS[i], 0, sizeof(shcupd_peer_opt));
+  
+  r->SHCUPD_MCASTIF     = NULL;
+  r->SHCUPD_MCASTTTL    = NULL;
+#endif
+
+  r->QUIET              = 0;
+  r->SYSLOG             = 0;
+  r->TCP_KEEPALIVE_TIME = 3600;
+  r->DAEMONIZE          = 0;
+  r->PREFER_SERVER_CIPHERS = 0;
+
+  return r;
+}
+
+void config_destroy (stud_config *cfg) {
+  // printf("config_destroy() in pid %d: %p\n", getpid(), cfg);
+  if (cfg == NULL) return;
+
+  // free all members!
+  if (cfg->CHROOT != NULL) free(cfg->CHROOT);
+  if (cfg->FRONT_IP != NULL) free(cfg->FRONT_IP);
+  if (cfg->FRONT_PORT != NULL) free(cfg->FRONT_PORT);
+  if (cfg->BACK_IP != NULL) free(cfg->BACK_IP);
+  if (cfg->BACK_PORT != NULL) free(cfg->BACK_PORT);
+  if (cfg->CERT_FILE != NULL) free(cfg->CERT_FILE);
+  if (cfg->CIPHER_SUITE != NULL) free(cfg->CIPHER_SUITE);
+  if (cfg->ENGINE != NULL) free(cfg->ENGINE);
+
+#ifdef USE_SHARED_CACHE
+  if (cfg->SHCUPD_IP != NULL) free(cfg->SHCUPD_IP);
+  if (cfg->SHCUPD_PORT != NULL) free(cfg->SHCUPD_PORT);
+
+  for (int i = 0; i < MAX_SHCUPD_PEERS; i++) {
+    if (cfg->SHCUPD_PEERS[i].ip != NULL)
+      free(cfg->SHCUPD_PEERS[i].ip);
+    if (cfg->SHCUPD_PEERS[i].port != NULL)
+      free(cfg->SHCUPD_PEERS[i].port);    
+  }
+
+  if (cfg->SHCUPD_MCASTIF != NULL) free(cfg->SHCUPD_MCASTIF);
+  if (cfg->SHCUPD_MCASTTTL != NULL) free(cfg->SHCUPD_MCASTTTL);
+#endif
+
+  free(cfg);
+}
+
+char * config_get_param (char *str) {
+  char *ptr;
+  int i;
+
+  if (str == NULL) return NULL;
+  /** empty string? */
+  if (strlen(str) < 1 || str[0] == '\n' || strcmp(str, "\r\n") == 0) return NULL;
+
+  ptr = str;
+
+  /** comments? */
+  if (str[0] == '#') return NULL;
+  /** first alpha character */
+  while (ptr != NULL && ! isalpha(*ptr))
+    ptr++;
+
+  /** overwrite alpha chars */
+  memset(var_buf, '\0', sizeof(var_buf));
+  i = 0;
+  while(ptr != NULL && (isalnum(*ptr) || *ptr == '-')) {
+    var_buf[i] = *ptr;
+    i++;
+    ptr++;
+  }
+
+  if (strlen(var_buf) < 1) return NULL;
+  return var_buf;
+}
+
+char * config_get_value (char *str) {
+  char *ptr;
+  int i = 0;
+
+  if (str == NULL) return NULL;
+  if (strlen(str) < 1) return NULL;
+
+  /** find '=' char */
+  ptr = str;
+  while (ptr != NULL && (*ptr) != '=')
+    ptr++;
+  ptr++;
+
+  /** skip whitespaces **/
+  while (ptr != NULL && ! isgraph(*ptr))
+    ptr++;
+
+  /** no value found? */
+  if (ptr == NULL) return NULL;
+
+  /** overwrite alpha chars */
+  memset(val_buf, '\0', sizeof(val_buf));
+  while(ptr != NULL && isgraph(*ptr)) {
+    val_buf[i++] = *ptr;
+    ptr++;
+  }
+
+  if (strlen(val_buf) < 1) return NULL;
+  return val_buf;
+}
+
+char * str_rtrim(char *str) {
+  char *ptr;
+  int   len;
+ 
+  len = strlen(str);
+  ptr = str + len - 1;
+  while (ptr >= str && (isspace((int)*ptr ) || (char) *ptr == '"' || (char) *ptr == '\'')) --ptr;
+ 
+  ptr[1] = '\0';
+ 
+  return str;
+}
+ 
+char * str_ltrim(char *str) {
+  char *ptr;
+  int  len;
+ 
+  for (ptr = str; (*ptr && (isspace((int)*ptr) || (char) *ptr == '"' || (char) *ptr == '\'')); ++ptr);
+ 
+  len = strlen(ptr);
+  memmove(str, ptr, len + 1);
+ 
+  return str;
+}
+ 
+char * str_trim(char *str) {
+  char *ptr;
+  ptr = str_rtrim(str);
+  str = str_ltrim(ptr);
+  return str;
+}
+
+char * config_assign_str (char **dst, char *v) {
+  if (*dst == NULL) {
+    if (v != NULL && strlen(v) > 0)
+      *dst = strdup(v);
+  } else {
+    if (v != NULL && strlen(v) > 0) {
+      // we assume that there is enough room for v in *dst
+      memset(*dst, '\0', strlen(v) + 1);
+      memcpy(*dst, v, strlen(v));
+    }
+    else
+      free(*dst);
+  }
+  return *dst;
+}
+
+int config_param_val_bool (char *val, int *res) {
+  if (val == NULL) return 0;
+  if (
+    strcasecmp(val, CFG_BOOL_ON) == 0 ||
+    strcasecmp(val, "yes") == 0 ||
+    strcasecmp(val, "y") == 0 ||
+    strcasecmp(val, "true") == 0 ||
+    strcasecmp(val, "t") == 0 ||
+    strcasecmp(val, "1") == 0) {
+    *res = 1;
+  }
+  
+  return 1;
+}
+
+char * config_param_val_str (char *val) {
+  return strdup(val);
+}
+
+int config_param_host_port_wildcard (char *str, char **addr, char **port, int wildcard_okay) {
+  int len = (str != NULL) ? strlen(str) : 0;
+  if (str == NULL || ! len) {
+    config_error_set("Invalid/unset host/port string.");
+    return 0;
+  }
+
+  // address/port buffers
+  char port_buf[PORT_LEN];
+  char addr_buf[ADDR_LEN];
+  
+  memset(port_buf, '\0', sizeof(port_buf));
+  memset(addr_buf, '\0', sizeof(addr_buf));
+  
+  // NEW FORMAT: [address]:port
+  if (*str == '[') {
+    char *ptr = str + 1;
+    char *x = strrchr(ptr, ']');
+    if (x == NULL) {
+      config_error_set("Invalid address '%s'.", str);
+      return 0;
+    }
+    
+    // address
+    memcpy(addr_buf, ptr, (x - ptr));
+    
+    // port
+    x += 2;
+    memcpy(port_buf, x, sizeof(port_buf) - 1);
+  }
+  // OLD FORMAT: address,port
+  else {
+    char *x = strrchr(str, ',');
+    if (x == NULL) {
+      config_error_set("Invalid address string '%s'", str);
+      return 0;
+    }
+    // addr
+    int addr_len = x - str;
+    memcpy(addr_buf, str, addr_len);
+    // port
+    memcpy(port_buf, (++x), sizeof(port_buf));
+  }
+  
+  // printf("PARSED ADDR '%s', PORT '%s'\n", addr_buf, port_buf);
+  
+  // check port
+  int p = atoi(port_buf);
+  if (p < 1 || p > 65536) {
+    config_error_set("Invalid port number '%s'", port_buf);
+    return 0;
+  }
+  
+  // write
+  if (strcmp(addr_buf, "*") == 0) {
+    if (wildcard_okay)
+      free(*addr);
+    else {
+      config_error_set("Invalid address: wildcards are not allowed.");
+      return 0;
+    }
+  } else {
+    //if (*addr != NULL) free(*addr);
+    *addr = strdup(addr_buf);
+  }
+  // if (**port != NULL) free(*port);
+  *port = strdup(port_buf);
+  
+  // printf("ADDR FINAL: '%s', '%s'\n", *addr, *port);
+  
+  return 1;
+}
+
+int config_param_host_port (char *str, char **addr, char **port) {
+  return config_param_host_port_wildcard(str, addr, port, 0);
+}
+
+int config_param_val_int (char *str, int *dst) {
+  *dst = (str != NULL) ? atoi(str) : 0;
+  return 1;
+}
+
+int config_param_val_int_pos (char *str, int *dst) {
+  int num = 0;
+  if (str != NULL)
+    num = atoi(str);
+  
+  if (num < 1) {
+    config_error_set("Not a positive number.");
+    return 0;
+  }
+  
+  *dst = num;
+  return 1;
+}
+
+int config_param_val_intl (char *str, long int *dst) {
+  *dst = (str != NULL) ? atol(str) : 0;
+  return 1;
+}
+
+int config_param_val_intl_pos (char *str, long int *dst) {
+  long int num = 0;
+  if (str != NULL)
+    num = atol(str);
+  
+  if (num < 1) {
+    config_error_set("Not a positive number.");
+    return 0;
+  }
+  
+  *dst = num;
+  return 1;
+}
+
+#ifdef USE_SHARED_CACHE
+/* Parse mcast and ttl options */
+int config_param_shcupd_mcastif (char *str, char **iface, char **ttl) {
+    char buf[150];
+    char *sp;
+
+    if (strlen(str) >= sizeof buf) {
+      config_error_set("Invalid option for IFACE[,TTL]");
+      return 0;
+    }
+
+    sp = strchr(str, ',');
+    if (!sp) {
+        if (!strcmp(str, "*"))
+            *iface = NULL;
+        else
+            *iface = str;
+        *ttl = NULL;
+        return 1;
+    }
+    else if (!strncmp(str, "*", sp - str)) {
+        *iface = NULL;
+    }
+    else {
+        *sp = 0;
+        *iface = str;
+    }
+    *ttl = sp + 1;
+    
+    return 1;
+}
+
+int config_param_shcupd_peer (char *str, stud_config *cfg) {
+  if (cfg == NULL) {
+    config_error_set("Configuration pointer is NULL.");
+    return 0;
+  }
+  
+  // parse result
+  int r = 1;
+
+  // find place for new peer
+  int offset = 0;
+  int i = 0;
+  for (i = 0; i < MAX_SHCUPD_PEERS; i++) {
+    if (cfg->SHCUPD_PEERS[i].ip == NULL && cfg->SHCUPD_PEERS[i].port == NULL) {
+      offset = i;
+      break;
+    }
+  }
+  if (i >= MAX_SHCUPD_PEERS) {
+    config_error_set(
+      "Reached maximum number of shared cache update peers (%d).",
+      MAX_SHCUPD_PEERS
+    );
+    return 0;
+  }
+  
+  // create place for new peer
+  char *addr = malloc(ADDR_LEN);
+  if (addr == NULL) {
+    config_error_set(
+      "Unable to allocate memory for new shared cache update peer address: %s",
+      strerror(errno)
+    );
+    r = 0;
+    goto outta_parse_peer;
+  }
+  memset(addr, '\0', ADDR_LEN);
+  char *port = malloc(PORT_LEN);
+  if (port == NULL) {
+    config_error_set(
+      "Unable to allocate memory for new shared cache update peer port: %s",
+      strerror(errno)
+    );
+    r = 0;
+    goto outta_parse_peer;
+  }
+  memset(port, '\0', PORT_LEN);
+  
+  // try to parse address
+  if (! config_param_host_port(str, &addr, &port)) {
+    r = 0;
+    goto outta_parse_peer;
+  }
+  
+  outta_parse_peer:
+
+  if (! r) {
+    if (addr != NULL) free(addr);
+    if (port != NULL) free(port);
+  } else {
+    cfg->SHCUPD_PEERS[offset].ip = addr;
+    cfg->SHCUPD_PEERS[offset].port = port;
+  }
+  
+  return r;
+}
+
+#endif /* USE_SHARED_CACHE */
+
+void config_param_validate (char *k, char *v, stud_config *cfg, char *file, int line) {
+  int r = 1;
+  struct stat st;
+      
+  if (strcmp(k, "tls") == 0) {
+    //cfg->ENC_TLS = 1;
+  }
+  else if (strcmp(k, "ssl") == 0) {
+    //cfg->ENC_TLS = 0;
+  }
+  else if (strcmp(k, CFG_CIPHERS) == 0) {
+    if (v != NULL && strlen(v) > 0) {
+      config_assign_str(&cfg->CIPHER_SUITE, v);
+    }
+  }
+  else if (strcmp(k, CFG_SSL_ENGINE) == 0) {
+    if (v != NULL && strlen(v) > 0) {
+      config_assign_str(&cfg->ENGINE, v);
+    }
+  }
+  else if (strcmp(k, CFG_PREFER_SERVER_CIPHERS) == 0) {
+    r = config_param_val_bool(v, &cfg->PREFER_SERVER_CIPHERS);
+  }
+  else if (strcmp(k, CFG_FRONTEND) == 0) {
+    r = config_param_host_port_wildcard(v, &cfg->FRONT_IP, &cfg->FRONT_PORT, 1);
+  }
+  else if (strcmp(k, CFG_BACKEND) == 0) {
+    r = config_param_host_port(v, &cfg->BACK_IP, &cfg->BACK_PORT);
+  }
+  else if (strcmp(k, CFG_WORKERS) == 0) {
+    r = config_param_val_intl_pos(v, &cfg->NCORES);
+  }
+  else if (strcmp(k, CFG_BACKLOG) == 0) {
+    r = config_param_val_int(v, &cfg->BACKLOG);
+    if (r && cfg->BACKLOG < -1) cfg->BACKLOG = -1;
+  }
+  else if (strcmp(k, CFG_KEEPALIVE) == 0) {
+    r = config_param_val_int_pos(v, &cfg->TCP_KEEPALIVE_TIME);
+  }
+#ifdef USE_SHARED_CACHE
+  else if (strcmp(k, CFG_SHARED_CACHE) == 0) {
+    r = config_param_val_int(v, &cfg->SHARED_CACHE);
+  }
+  else if (strcmp(k, CFG_SHARED_CACHE_LISTEN) == 0) {
+    if (v != NULL && strlen(v) > 0)
+      r = config_param_host_port_wildcard(v, &cfg->SHCUPD_IP, &cfg->SHCUPD_PORT, 1);
+  }
+  else if (strcmp(k, CFG_SHARED_CACHE_PEER) == 0) {
+    r = config_param_shcupd_peer(v, cfg);
+  }
+  else if (strcmp(k, CFG_SHARED_CACHE_MCASTIF) == 0) {
+    r = config_param_shcupd_mcastif(v, &cfg->SHCUPD_MCASTIF, &cfg->SHCUPD_MCASTTTL);
+  }
+#endif
+  else if (strcmp(k, CFG_CHROOT) == 0) {
+    if (v != NULL && strlen(v) > 0) {
+      // check directory
+      if (stat(v, &st) != 0) {
+        config_error_set("Unable to stat directory '%s': %s'.", v, strerror(errno));
+        r = 0;
+      } else {
+        if (! S_ISDIR(st.st_mode)) {
+          config_error_set("Bad chroot directory '%s': Not a directory.", v, strerror(errno));
+          r = 0;
+        } else {
+          config_assign_str(&cfg->CHROOT, v);
+        }
+      }
+    }
+  }
+  else if (strcmp(k, CFG_USER) == 0) {
+    if (v != NULL && strlen(v) > 0) {
+      struct passwd *passwd;
+      passwd = getpwnam(v);
+      if (!passwd) {
+        config_error_set("Invalid user '%s'.", v);
+        r = 0;
+      } else {
+        cfg->UID = passwd->pw_uid;
+        cfg->GID = passwd->pw_gid;    
+      }
+    }
+  }
+  else if (strcmp(k, CFG_GROUP) == 0) {
+    if (v != NULL && strlen(v) > 0) {
+      struct group *grp;
+      grp = getgrnam(v);
+      if (!grp) {
+        config_error_set("Invalid group '%s'.", v);
+        r = 0;
+      } else {
+        cfg->GID = grp->gr_gid;    
+      }
+    }
+  }
+  else if (strcmp(k, CFG_QUIET) == 0) {
+    r = config_param_val_bool(v, &cfg->QUIET);
+  }
+  else if (strcmp(k, CFG_SYSLOG) == 0) {
+    r = config_param_val_bool(v, &cfg->SYSLOG);
+  }
+  else if (strcmp(k, CFG_DAEMON) == 0) {
+    r = config_param_val_bool(v, &cfg->DAEMONIZE);
+  }
+  else if (strcmp(k, CFG_WRITE_IP) == 0) {
+    r = config_param_val_bool(v, &cfg->WRITE_IP_OCTET);
+  }
+  else if (strcmp(k, CFG_WRITE_PROXY) == 0) {
+    r = config_param_val_bool(v, &cfg->WRITE_PROXY_LINE);
+  }
+  else if (strcmp(k, CFG_PEM_FILE) == 0) {
+    if (v != NULL && strlen(v) > 0) {
+      if (stat(v, &st) != 0) {
+        config_error_set("Unable to stat x509 certificate PEM file '%s': ", v, strerror(errno));
+        r = 0;
+      }
+      else if (! S_ISREG(st.st_mode)) {
+        config_error_set("Invalid x509 certificate PEM file '%s': Not a file.", v);
+        r = 0;        
+      } else
+        config_assign_str(&cfg->CERT_FILE, v);
+    }
+  }
+  else {
+    fprintf(
+      stderr,
+      "Ignoring unknown configuration key '%s' in configuration file '%s', line %d\n",
+      k, file, line
+    );
+  }
+  
+  if (! r) {
+    if (file != NULL)
+      config_die("Error in configuration file '%s', line %d: %s\n", file, line, config_error_get()); 
+    else
+      config_die("Invalid parameter '%s': %s", k, config_error_get());
+  }
+}
+
+#ifndef NO_CONFIG_FILE
+int config_file_parse (char *file, stud_config *cfg) {
+  if (cfg == NULL)
+    config_die("Undefined stud options; THIS IS A BUG!\n");
+  
+  char line[CONFIG_BUF_SIZE];
+  FILE *fd = NULL;
+
+  // should we read stdin?
+  if (file == NULL || strlen(file) < 1 || strcmp(file, "-") == 0) {
+    fd = stdin;
+  } else {
+    fd = fopen(file, "r");
+  }
+  if (fd == NULL)
+      config_die("Unable to open configuration file '%s': %s\n", file, strerror(errno));
+
+  // read config
+  int i = 0;
+  while (i < CONFIG_MAX_LINES) {
+    memset(line, '\0', sizeof(line));
+    if (fgets(line, (sizeof(line) - 1), fd) == NULL) break;
+    i++;
+    
+    // get configuration key
+    char *key, *val;
+    key = config_get_param(line);
+    if (key == NULL) continue;
+    
+    // get configuration key value...
+    val = config_get_value(line);
+    if (val == NULL) continue;
+    str_trim(val);
+    
+    // printf("File '%s', line %d, key: '%s', value: '%s'\n", file, i, key, val);
+    
+    // validate configuration key => value
+    config_param_validate(key, val, cfg, file, i);
+  }
+
+  fclose(fd);
+  
+  return 1;
+}
+#endif /* NO_CONFIG_FILE */
+
+char * config_disp_str (char *str) {
+  return (str == NULL) ? "" : str;
+}
+
+char * config_disp_bool (int v) {
+  return (v > 0) ? CFG_BOOL_ON : "off";
+}
+
+char * config_disp_uid (uid_t uid) {
+  memset(tmp_buf, '\0', sizeof(tmp_buf));
+  if (uid == 0 && geteuid() != 0) return tmp_buf;
+  struct passwd *pw = getpwuid(uid);
+  if (pw) {
+    memcpy(tmp_buf, pw->pw_name, strlen(pw->pw_name));
+  }
+  return tmp_buf;
+}
+
+char * config_disp_gid (gid_t gid) {
+  memset(tmp_buf, '\0', sizeof(tmp_buf));
+  if (gid == 0 && geteuid() != 0) return tmp_buf;
+  struct group *gr = getgrgid(gid);
+  if (gr) {
+    memcpy(tmp_buf, gr->gr_name, strlen(gr->gr_name));
+  }
+  return tmp_buf;  
+}
+
+char * config_disp_hostport (char *host, char *port) {
+  memset(tmp_buf, '\0', sizeof(tmp_buf));
+  if (host == NULL && port == NULL)
+    return "";
+
+  strcat(tmp_buf, "[");
+  if (host == NULL)
+    strcat(tmp_buf, "*");
+  else {
+    strncat(tmp_buf, host, 40);
+  }
+  strcat(tmp_buf, "]:");
+  strncat(tmp_buf, port, 5);
+  return tmp_buf;
+}
+
+void config_print_usage_fd (char *prog, stud_config *cfg, FILE *out) {
+  if (out == NULL) out = stderr;
+  fprintf(out, "Usage: %s [OPTIONS] PEM\n\n", basename(prog));
+  fprintf(out, "This is stud, The Scalable TLS Unwrapping Daemon.\n\n");
+#ifndef NO_CONFIG_FILE
+  fprintf(out, "CONFIGURATION:\n");
+  fprintf(out, "\n");
+  fprintf(out, "        --config=FILE      Load configuration from specified file.\n");
+  fprintf(out, "        --default-config   Prints default configuration to stdout.\n");
+  fprintf(out, "\n");
+#endif
+  fprintf(out, "ENCRYPTION METHODS:\n");
+  fprintf(out, "\n");
+  fprintf(out, "      --tls                   TLSv1 (default)\n");
+  fprintf(out, "      --ssl                   SSLv3 (implies no TLSv1)\n");
+  fprintf(out, "  -c  --ciphers=SUITE         Sets allowed ciphers (Default: \"%s\")\n", config_disp_str(cfg->CIPHER_SUITE));
+  fprintf(out, "  -e  --ssl-engine=NAME       Sets OpenSSL engine (Default: \"%s\")\n", config_disp_str(cfg->ENGINE));
+  fprintf(out, "  -O  --prefer-server-ciphers Prefer server list order\n");
+  fprintf(out, "\n");
+  fprintf(out, "SOCKET:\n");
+  fprintf(out, "\n");
+  fprintf(out, "  -b  --backend=HOST,PORT     Backend [connect] (default is \"%s\")\n", config_disp_hostport(cfg->BACK_IP, cfg->BACK_PORT));
+  fprintf(out, "  -f  --frontend=HOST,PORT    Frontend [bind] (default is \"%s\")\n", config_disp_hostport(cfg->FRONT_IP, cfg->FRONT_PORT));
+
+#ifdef USE_SHARED_CACHE
+  fprintf(out, "\n");
+  fprintf(out, "  -U  --shared-cache-listen=HOST,PORT\n");
+  fprintf(out, "                              Accept cache updates on UDP (Default: \"%s\")\n", config_disp_hostport(cfg->SHCUPD_IP, cfg->SHCUPD_PORT));
+  fprintf(out, "                              NOTE: This option requires enabled SSL session cache.\n");
+  fprintf(out, "  -P  --shared-cache-peer=HOST,PORT\n");
+  fprintf(out, "                              Send cache updates to specified peer\n");
+  fprintf(out, "                              NOTE: This option can be specified multiple times.\n");
+  fprintf(out, "  -M  --shared-cache-if=IFACE[,TTL]\n");
+  fprintf(out, "                              Force iface and ttl to receive and send multicast updates\n");
+#endif
+
+  fprintf(out, "\n");
+  fprintf(out, "PERFORMANCE:\n");
+  fprintf(out, "\n");
+  fprintf(out, "  -n  --workers=NUM          Number of worker processes (Default: %ld)\n", cfg->NCORES);
+  fprintf(out, "  -B  --backlog=NUM          Set listen backlog size (Default: %d)\n", cfg->BACKLOG);
+  fprintf(out, "  -k  --keepalive=SECS       TCP keepalive on client socket (Default: %d)\n", cfg->TCP_KEEPALIVE_TIME);
+
+#ifdef USE_SHARED_CACHE
+  fprintf(out, "  -C  --session-cache=NUM    Enable and set SSL session cache to specified number\n");
+  fprintf(out, "                             of sessions (Default: %d)\n", cfg->SHARED_CACHE);
+#endif
+
+  fprintf(out, "\n");
+  fprintf(out, "SECURITY:\n");
+  fprintf(out, "\n");
+  fprintf(out, "  -r  --chroot=DIR           Sets chroot directory (Default: \"%s\")\n", config_disp_str(cfg->CHROOT));
+  fprintf(out, "  -u  --user=USER            Set uid/gid after binding the socket (Default: \"%s\")\n", config_disp_uid(cfg->UID));
+  fprintf(out, "  -g  --group=GROUP          Set gid after binding the socket (Default: \"%s\")\n", config_disp_gid(cfg->GID));
+  fprintf(out, "\n");
+  fprintf(out, "LOGGING:\n");
+  fprintf(out, "  -q  --quiet                Be quiet; emit only error messages\n");
+  fprintf(out, "  -s  --syslog               Send log message to syslog in addition to stderr/stdout\n");
+  fprintf(out, "\n");
+  fprintf(out, "OTHER OPTIONS:\n");
+  fprintf(out, "      --daemon               Fork into background and become a daemon (Default: %s)\n", config_disp_bool(cfg->DAEMONIZE));
+  fprintf(out, "      --write-ip             Write 1 octet with the IP family followed by the IP\n");
+  fprintf(out, "                             address in 4 (IPv4) or 16 (IPv6) octets little-endian\n");
+  fprintf(out, "                             to backend before the actual data\n");
+  fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->WRITE_IP_OCTET));
+  fprintf(out, "      --write-proxy          Write HaProxy's PROXY (IPv4 or IPv6) protocol line\n" );
+  fprintf(out, "                             before actual data\n");
+  fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->WRITE_PROXY_LINE));
+  fprintf(out, "\n");
+  fprintf(out, "  -t  --test                 Test configuration and exit\n");
+  fprintf(out, "  -V  --version              Print program version and exit\n");
+  fprintf(out, "  -h  --help                 This help message\n");
+}
+
+#ifndef NO_CONFIG_FILE
+void config_print_default (FILE *fd, stud_config *cfg) {
+  if (fd == NULL) return;
+  fprintf(fd, "#\n");
+  fprintf(fd, "# stud(8), The Scalable TLS Unwrapping Daemon's configuration\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "\n");
+  fprintf(fd, "# NOTE: all config file parameters can be overriden\n");
+  fprintf(fd, "#       from command line!\n");
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Listening address. REQUIRED.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, "# syntax: [HOST]:PORT\n");
+  fprintf(fd, FMT_QSTR, CFG_FRONTEND, config_disp_hostport(cfg->FRONT_IP, cfg->FRONT_PORT));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Upstream server address. REQUIRED.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, "# syntax: [HOST]:PORT.\n");
+  fprintf(fd, FMT_QSTR, CFG_BACKEND, config_disp_hostport(cfg->BACK_IP, cfg->BACK_PORT));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# SSL x509 certificate file. REQUIRED.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, FMT_QSTR, CFG_PEM_FILE, config_disp_str(cfg->CERT_FILE));
+  fprintf(fd, "\n");
+  
+  fprintf(fd, "# SSL protocol.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# tls = on\n");
+  fprintf(fd, "# ssl = off\n");
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# List of allowed SSL ciphers.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# Run openssl ciphers for list of available ciphers.\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, FMT_QSTR, CFG_CIPHERS, config_disp_str(cfg->CIPHER_SUITE));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Enforce server cipher list order\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: boolean\n");
+  fprintf(fd, FMT_STR, CFG_PREFER_SERVER_CIPHERS, config_disp_bool(cfg->PREFER_SERVER_CIPHERS));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Use specified SSL engine\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, FMT_QSTR, CFG_SSL_ENGINE, config_disp_str(cfg->ENGINE));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Number of worker processes\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: integer\n");
+  fprintf(fd, FMT_ISTR, CFG_WORKERS, (int) cfg->NCORES);
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Listen backlog size\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: integer\n");
+  fprintf(fd, FMT_ISTR, CFG_BACKLOG, cfg->BACKLOG);
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# TCP socket keepalive interval in seconds\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: integer\n");
+  fprintf(fd, FMT_ISTR, CFG_KEEPALIVE, cfg->TCP_KEEPALIVE_TIME);
+  fprintf(fd, "\n");
+
+#ifdef USE_SHARED_CACHE
+  fprintf(fd, "# SSL session cache size\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: integer\n");
+  fprintf(fd, FMT_ISTR, CFG_SHARED_CACHE, cfg->SHARED_CACHE);
+  fprintf(fd, "\n");
+  
+  fprintf(fd, "# Accept shared SSL cache updates on specified listener.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, "# syntax: [HOST]:PORT\n");
+  fprintf(fd, FMT_QSTR, CFG_SHARED_CACHE_LISTEN, config_disp_hostport(cfg->SHCUPD_IP, cfg->SHCUPD_PORT));
+  fprintf(fd, "\n");
+  
+  fprintf(fd, "# Shared cache peer address.\n");
+  fprintf(fd, "# Multiple stud processes on multiple hosts (host limit: %d)\n", MAX_SHCUPD_PEERS);
+  fprintf(fd, "# can share SSL session cache by sending updates to peers.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# NOTE: This parameter can be specified multiple times in order\n");
+  fprintf(fd, "#       to specify multiple peers.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, "# syntax: [HOST]:PORT\n");
+  fprintf(fd, "# " FMT_QSTR, CFG_SHARED_CACHE_PEER, config_disp_hostport(NULL, NULL));
+  for (int i = 0; i < MAX_SHCUPD_PEERS; i++) {
+    if (cfg->SHCUPD_PEERS[i].ip == NULL && cfg->SHCUPD_PEERS[i].port == NULL) break;
+    fprintf(fd, FMT_QSTR, CFG_SHARED_CACHE_PEER, config_disp_hostport(cfg->SHCUPD_PEERS[i].ip, cfg->SHCUPD_PEERS[i].port));
+  }
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Shared cache interface name and optional TTL\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, "# syntax: iface[,TTL]\n");
+  fprintf(fd, "# %s = \"%s", CFG_SHARED_CACHE_MCASTIF, config_disp_str(cfg->SHCUPD_MCASTIF));
+  if (cfg->SHCUPD_MCASTTTL != NULL && strlen(cfg->SHCUPD_MCASTTTL) > 0) {
+    fprintf(fd, ",%s", cfg->SHCUPD_MCASTTTL);
+  }
+  fprintf(fd, "\"\n");
+  fprintf(fd, "\n");
+#endif
+
+  fprintf(fd, "# Chroot directory\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, FMT_QSTR, CFG_CHROOT, config_disp_str(cfg->CHROOT));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Set uid after binding a socket\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, FMT_QSTR, CFG_USER, config_disp_uid(cfg->UID));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Set gid after binding a socket\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: string\n");
+  fprintf(fd, FMT_QSTR, CFG_GROUP, config_disp_gid(cfg->GID));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Quiet execution, report only error messages\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: boolean\n");
+  fprintf(fd, FMT_STR, CFG_QUIET, config_disp_bool(cfg->QUIET));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Use syslog for logging\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: boolean\n");
+  fprintf(fd, FMT_STR, CFG_SYSLOG, config_disp_bool(cfg->SYSLOG));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Run as daemon\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: boolean\n");
+  fprintf(fd, FMT_STR, CFG_DAEMON, config_disp_bool(cfg->DAEMONIZE));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Report client address by writing IP before sending data\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# NOTE: This option is mutually exclusive with option %s.\n", CFG_WRITE_PROXY);
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: boolean\n");
+  fprintf(fd, FMT_STR, CFG_WRITE_IP, config_disp_bool(cfg->WRITE_IP_OCTET));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Report client address using SENDPROXY protocol, see\n");
+  fprintf(fd, "# http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt\n");
+  fprintf(fd, "# for details.\n");
+  fprintf(fd, "#\n");
+  fprintf(fd, "# NOTE: This option is mutually exclusive with option %s.\n", CFG_WRITE_IP);
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: boolean\n");
+  fprintf(fd, FMT_STR, CFG_WRITE_PROXY, config_disp_bool(cfg->WRITE_PROXY_LINE));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# EOF\n");
+}
+#endif /* NO_CONFIG_FILE */
+
+void config_print_usage (char *prog, stud_config *cfg) {
+  config_print_usage_fd(prog, cfg, stdout);
+}
+
+void config_parse_cli(int argc, char **argv, stud_config *cfg) {
+  static int tls = 0, ssl = 0;
+  int c;
+  int test_only = 0;
+  char *prog;
+
+  struct option long_options[] = {
+#ifndef NO_CONFIG_FILE
+    { CFG_CONFIG, 1, NULL, CFG_PARAM_CFGFILE },
+    { CFG_CONFIG_DEFAULT, 0, NULL, CFG_PARAM_DEFCFG },
+#endif
+    
+    { "tls", 0, &tls, 1},
+    { "ssl", 0, &ssl, 1},    
+    { CFG_CIPHERS, 1, NULL, 'c' },
+    { CFG_PREFER_SERVER_CIPHERS, 0, NULL, 'O' },
+    { CFG_BACKEND, 1, NULL, 'b' },
+    { CFG_FRONTEND, 1, NULL, 'f' },
+    { CFG_WORKERS, 1, NULL, 'n' },
+    { CFG_BACKLOG, 1, NULL, 'B' },
+#ifdef USE_SHARED_CACHE
+    { CFG_SHARED_CACHE, 1, NULL, 'C' },
+    { CFG_SHARED_CACHE_LISTEN, 1, NULL, 'U' },
+    { CFG_SHARED_CACHE_PEER, 1, NULL, 'P' },
+    { CFG_SHARED_CACHE_MCASTIF, 1, NULL, 'M' },
+#endif
+    { CFG_KEEPALIVE, 1, NULL, 'k' },
+    { CFG_CHROOT, 1, NULL, 'r' },
+    { CFG_USER, 1, NULL, 'u' },
+    { CFG_GROUP, 1, NULL, 'g' },
+    { CFG_QUIET, 0, NULL, 'q' },
+    { CFG_SYSLOG, 0, NULL, 's' },
+    { CFG_DAEMON, 0, &cfg->DAEMONIZE, 1 },
+    { CFG_WRITE_IP, 0, &cfg->WRITE_IP_OCTET, 1 },
+    { CFG_WRITE_PROXY, 0, &cfg->WRITE_PROXY_LINE, 1 },
+ 
+    { "test", 0, NULL, 't' },
+    { "version", 0, NULL, 'V' },
+    { "help", 0, NULL, 'h' },
+    { 0, 0, 0, 0 }
+  };
+
+  while (1) {
+    int option_index = 0;
+    c = getopt_long(
+      argc, argv,
+      "c:e:Ob:f:n:B:C:U:P:M:k:r:u:g:qstVh",
+      long_options, &option_index
+    );
+
+    if (c == -1)
+      break;
+
+    switch (c) {
+      case 0:
+        break;
+#ifndef NO_CONFIG_FILE
+      case CFG_PARAM_CFGFILE:
+        if (!config_file_parse(optarg, cfg))
+          config_die("%s", config_error_get());
+        break;
+      case CFG_PARAM_DEFCFG:
+        config_print_default(stdout, cfg);
+        exit(0);
+        break;
+#endif
+      case 'c':
+        config_param_validate(CFG_CIPHERS, optarg, cfg, NULL, 0);
+        break;
+      case 'e':
+        config_param_validate(CFG_SSL_ENGINE, optarg, cfg, NULL, 0);
+         break;
+      case 'O':
+        config_param_validate(CFG_PREFER_SERVER_CIPHERS, CFG_BOOL_ON, cfg, NULL, 0);
+        break;
+      case 'b':
+        config_param_validate(CFG_BACKEND, optarg, cfg, NULL, 0);
+        break;
+      case 'f':
+        config_param_validate(CFG_FRONTEND, optarg, cfg, NULL, 0);
+        break;
+      case 'n':
+        config_param_validate(CFG_WORKERS, optarg, cfg, NULL, 0);
+        break;
+      case 'B':
+        config_param_validate(CFG_BACKLOG, optarg, cfg, NULL, 0);
+        break;
+#ifdef USE_SHARED_CACHE
+      case 'C':
+        config_param_validate(CFG_SHARED_CACHE, optarg, cfg, NULL, 0);
+        break;
+      case 'U':
+        config_param_validate(CFG_SHARED_CACHE_LISTEN, optarg, cfg, NULL, 0);
+        break;
+      case 'P':
+        config_param_validate(CFG_SHARED_CACHE_PEER, optarg, cfg, NULL, 0); 
+        break;
+      case 'M':
+        config_param_validate(CFG_SHARED_CACHE_MCASTIF, optarg, cfg, NULL, 0);
+        break;
+#endif
+      case 'k':
+        config_param_validate(CFG_KEEPALIVE, optarg, cfg, NULL, 0);
+        break;
+      case 'r':
+        config_param_validate(CFG_CHROOT, optarg, cfg, NULL, 0);
+        break;
+      case 'u':
+        config_param_validate(CFG_USER, optarg, cfg, NULL, 0);
+        break;
+      case 'g':
+        config_param_validate(CFG_GROUP, optarg, cfg, NULL, 0);
+        break;
+      case 'q':
+        config_param_validate(CFG_QUIET, CFG_BOOL_ON, cfg, NULL, 0);
+        break;
+      case 's':
+        config_param_validate(CFG_SYSLOG, CFG_BOOL_ON, cfg, NULL, 0);
+        break;
+      case 't':
+        test_only = 1;
+        break;
+      case 'V':
+        printf("%s %s\n", basename(argv[0]), STUD_VERSION);
+        exit(0);
+        break;
+      case 'h':
+        config_print_usage(argv[0], cfg);
+        exit(0);
+        break;
+
+      default:
+        config_die("Invalid command line parameters. Run %s --help for instructions.", basename(argv[0]));
+    }
+  }
+  
+  prog = argv[0];
+
+  if (tls && ssl)
+    config_die("Options --tls and --ssl are mutually exclusive.");
+  else {
+    if (ssl)
+      cfg->ETYPE = ENC_SSL;
+    else if (tls)
+      cfg->ETYPE = ENC_TLS;
+  }
+
+  if (cfg->WRITE_IP_OCTET && cfg->WRITE_PROXY_LINE)
+    config_die("Options --write-ip and --write-proxy are mutually exclusive.");
+
+  if (cfg->DAEMONIZE) {
+    cfg->SYSLOG = 1;
+    cfg->QUIET = 1;
+  }
+
+#ifdef USE_SHARED_CACHE
+  if (cfg->SHCUPD_IP != NULL && ! cfg->SHARED_CACHE)
+    config_die("Shared cache update listener is defined, but shared cache is disabled.");
+#endif
+  
+  // argv leftovers, do we have pem file as an argument?
+  argc -= optind;
+  argv += optind;
+  if (argv != NULL && argv[0] != NULL)
+    config_param_validate(CFG_PEM_FILE, argv[0], cfg, NULL, 0);
+  else if (cfg->CERT_FILE == NULL || strlen(cfg->CERT_FILE) < 1)
+    config_die("No x509 certificate PEM file specified!");
+  
+  // was this only a test?
+  if (test_only) {
+    fprintf(stderr, "Trying to initialize SSL context with certificate '%s'\n", cfg->CERT_FILE);
+    if (! init_openssl())
+      config_die("Error initializing OpenSSL.");
+    printf("%s configuration looks ok.\n", basename(prog));
+    exit(0);
+  }
+}

--- a/configuration.h
+++ b/configuration.h
@@ -1,0 +1,67 @@
+/**
+ * configuration.h
+ *
+ * Author: Brane F. Gracnar
+ *
+ */
+
+#include <sys/types.h>
+
+#ifdef USE_SHARED_CACHE
+  #include "shctx.h"
+
+  #ifndef MAX_SHCUPD_PEERS
+    #define MAX_SHCUPD_PEERS 15
+  #endif
+
+typedef struct shcupd_peer_opt {
+     char *ip;
+     char *port;
+} shcupd_peer_opt;
+
+#endif
+
+typedef enum {
+    ENC_TLS,
+    ENC_SSL
+} ENC_TYPE;
+
+/* configuration structure */
+struct __stud_config {
+    ENC_TYPE ETYPE;
+    int WRITE_IP_OCTET;
+    int WRITE_PROXY_LINE;
+    char *CHROOT;
+    uid_t UID;
+    gid_t GID;
+    char *FRONT_IP;
+    char *FRONT_PORT;
+    char *BACK_IP;
+    char *BACK_PORT;
+    long NCORES;
+    char *CERT_FILE;
+    char *CIPHER_SUITE;
+    char *ENGINE;
+    int BACKLOG;
+#ifdef USE_SHARED_CACHE
+    int SHARED_CACHE;
+    char *SHCUPD_IP;
+    char *SHCUPD_PORT;
+    shcupd_peer_opt SHCUPD_PEERS[MAX_SHCUPD_PEERS+1];
+    char *SHCUPD_MCASTIF;
+    char *SHCUPD_MCASTTTL;
+#endif
+    int QUIET;
+    int SYSLOG;
+    int TCP_KEEPALIVE_TIME;
+    int DAEMONIZE;
+    int PREFER_SERVER_CIPHERS;
+};
+
+typedef struct __stud_config stud_config;
+
+char * config_error_get (void);
+stud_config * config_new (void);
+void config_destroy (stud_config *cfg);
+int config_file_parse (char *file, stud_config *cfg);
+void config_parse_cli(int argc, char **argv, stud_config *cfg);

--- a/stud.c
+++ b/stud.c
@@ -47,6 +47,7 @@
 #include <pwd.h>
 #include <limits.h>
 #include <syslog.h>
+#include <stdarg.h>
 
 #include <ctype.h>
 #include <sched.h>
@@ -60,6 +61,7 @@
 
 #include "ringbuffer.h"
 #include "shctx.h"
+#include "configuration.h"
 
 #ifndef MSG_NOSIGNAL
 # define MSG_NOSIGNAL 0
@@ -74,12 +76,6 @@
 #endif
 #ifndef SOL_TCP
 # define SOL_TCP IPPROTO_TCP
-#endif
-
-#ifdef USE_SHARED_CACHE
-#ifndef MAX_SHCUPD_PEERS
-# define MAX_SHCUPD_PEERS 15
-#endif
 #endif
 
 /* Globals */
@@ -98,85 +94,16 @@ static int shcupd_socket;
 struct addrinfo *shcupd_peers[MAX_SHCUPD_PEERS+1];
 static unsigned char shared_secret[SHA_DIGEST_LENGTH];
 
-typedef struct shcupd_peer_opt {
-     const char *ip;
-     const char *port;
-} shcupd_peer_opt;
+//typedef struct shcupd_peer_opt {
+//     const char *ip;
+//     const char *port;
+//} shcupd_peer_opt;
 
 #endif /*USE_SHARED_CACHE*/
 
 long openssl_version;
 int create_workers;
-
-/* Command line Options */
-typedef enum {
-    ENC_TLS,
-    ENC_SSL
-} ENC_TYPE;
-
-typedef struct stud_options {
-    ENC_TYPE ETYPE;
-    int WRITE_IP_OCTET;
-    int WRITE_PROXY_LINE;
-    const char* CHROOT;
-    uid_t UID;
-    gid_t GID;
-    const char *FRONT_IP;
-    const char *FRONT_PORT;
-    const char *BACK_IP;
-    const char *BACK_PORT;
-    long NCORES;
-    const char *CERT_FILE;
-    const char *CIPHER_SUITE;
-    const char *ENGINE;
-    int BACKLOG;
-#ifdef USE_SHARED_CACHE
-    int SHARED_CACHE;
-    const char *SHCUPD_IP;
-    const char *SHCUPD_PORT;
-    shcupd_peer_opt SHCUPD_PEERS[MAX_SHCUPD_PEERS+1];
-    const char *SHCUPD_MCASTIF;
-    const char *SHCUPD_MCASTTTL;
-#endif
-    int QUIET;
-    int SYSLOG;
-    int TCP_KEEPALIVE_TIME;
-    int DAEMONIZE;
-    int PREFER_SERVER_CIPHERS;
-} stud_options;
-
-static stud_options OPTIONS = {
-    ENC_TLS,      // ETYPE
-    0,            // WRITE_IP_OCTET
-    0,            // WRITE_PROXY_LINE
-    NULL,         // CHROOT
-    0,            // UID
-    0,            // GID
-    NULL,         // FRONT_IP
-    "8443",       // FRONT_PORT
-    "127.0.0.1",  // BACK_IP
-    "8000",       // BACK_PORT
-    1,            // NCORES
-    NULL,         // CERT_FILE
-    NULL,         // CIPHER_SUITE
-    NULL,         // ENGINE
-    100,          // BACKLOG
-#ifdef USE_SHARED_CACHE
-    0,            // SHARED_CACHE
-    NULL,         // SHCUPD_IP
-    NULL,         // SHCUPD_PORT
-    { { NULL, NULL } }, // SHCUPD_PEERS
-    NULL,         // SHCUPD_MCASTIF
-    NULL,         // SHCUPD_MCASTTTL
-#endif
-    0,            // QUIET
-    0,            // SYSLOG
-    3600,         // TCP_KEEPALIVE_TIME
-    0,            // DAEMONIZE
-    0             // PREFER_SERVER_CIPHERS
-};
-
-
+stud_config *CONFIG;
 
 static char tcp_proxy_line[128] = "";
 
@@ -220,14 +147,14 @@ typedef struct proxystate {
 
 #define LOG(...)                                        \
     do {                                                \
-      if (!OPTIONS.QUIET) fprintf(stdout, __VA_ARGS__); \
-      if (OPTIONS.SYSLOG) syslog(LOG_INFO, __VA_ARGS__);                    \
+      if (!CONFIG->QUIET) fprintf(stdout, __VA_ARGS__); \
+      if (CONFIG->SYSLOG) syslog(LOG_INFO, __VA_ARGS__);                    \
     } while(0)
 
 #define ERR(...)                    \
     do {                            \
       fprintf(stderr, __VA_ARGS__); \
-      if (OPTIONS.SYSLOG) syslog(LOG_ERR, __VA_ARGS__); \
+      if (CONFIG->SYSLOG) syslog(LOG_ERR, __VA_ARGS__); \
     } while(0)
 
 #define NULL_DEV "/dev/null"
@@ -248,7 +175,7 @@ static void settcpkeepalive(int fd) {
         ERR("Error activating SO_KEEPALIVE on client socket: %s", strerror(errno));
     }
 
-    optval = OPTIONS.TCP_KEEPALIVE_TIME;
+    optval = CONFIG->TCP_KEEPALIVE_TIME;
     optlen = sizeof(optval);
     if(setsockopt(fd, SOL_TCP, TCP_KEEPIDLE, &optval, optlen) < 0) {
         ERR("Error setting TCP_KEEPIDLE on client socket: %s", strerror(errno));
@@ -258,6 +185,15 @@ static void settcpkeepalive(int fd) {
 static void fail(const char* s) {
     perror(s);
     exit(1);
+}
+
+void die (char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+
+  exit(1);
 }
 
 #ifndef OPENSSL_NO_DH
@@ -407,7 +343,7 @@ static int create_shcupd_socket() {
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_DGRAM;
     hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
-    const int gai_err = getaddrinfo(OPTIONS.SHCUPD_IP, OPTIONS.SHCUPD_PORT,
+    const int gai_err = getaddrinfo(CONFIG->SHCUPD_IP, CONFIG->SHCUPD_PORT,
                                     &hints, &ai);
     if (gai_err != 0) {
         ERR("{getaddrinfo}: [%s]\n", gai_strerror(gai_err));
@@ -442,28 +378,28 @@ static int create_shcupd_socket() {
         memset(&mreqn, 0, sizeof(mreqn));
         mreqn.imr_multiaddr.s_addr = ((struct sockaddr_in *)ai->ai_addr)->sin_addr.s_addr;
 
-        if (OPTIONS.SHCUPD_MCASTIF) {
-            if (isalpha(*OPTIONS.SHCUPD_MCASTIF)) { /* appears to be an iface name */
+        if (CONFIG->SHCUPD_MCASTIF) {
+            if (isalpha(*CONFIG->SHCUPD_MCASTIF)) { /* appears to be an iface name */
                 struct ifreq ifr;
 
                 memset(&ifr, 0, sizeof(ifr));
-                if (strlen(OPTIONS.SHCUPD_MCASTIF) > IFNAMSIZ) {
-                    ERR("Error iface name is too long [%s]\n",OPTIONS.SHCUPD_MCASTIF);
+                if (strlen(CONFIG->SHCUPD_MCASTIF) > IFNAMSIZ) {
+                    ERR("Error iface name is too long [%s]\n",CONFIG->SHCUPD_MCASTIF);
                     exit(1);
                 }
 
-                memcpy(ifr.ifr_name, OPTIONS.SHCUPD_MCASTIF, strlen(OPTIONS.SHCUPD_MCASTIF));
+                memcpy(ifr.ifr_name, CONFIG->SHCUPD_MCASTIF, strlen(CONFIG->SHCUPD_MCASTIF));
                 if (ioctl(s, SIOCGIFINDEX, &ifr)) {
                     fail("{ioctl: SIOCGIFINDEX}");
                 }
 
                 mreqn.imr_ifindex = ifr.ifr_ifindex;
             }
-            else if (strchr(OPTIONS.SHCUPD_MCASTIF,'.')) { /* appears to be an ipv4 address */
-                mreqn.imr_address.s_addr = inet_addr(OPTIONS.SHCUPD_MCASTIF);
+            else if (strchr(CONFIG->SHCUPD_MCASTIF,'.')) { /* appears to be an ipv4 address */
+                mreqn.imr_address.s_addr = inet_addr(CONFIG->SHCUPD_MCASTIF);
             }
             else { /* appears to be an iface index */
-                mreqn.imr_ifindex = atoi(OPTIONS.SHCUPD_MCASTIF);
+                mreqn.imr_ifindex = atoi(CONFIG->SHCUPD_MCASTIF);
             }
         }
 
@@ -482,15 +418,15 @@ static int create_shcupd_socket() {
         }
 
         /* optional set sockopts for sending to multicast msg */
-        if (OPTIONS.SHCUPD_MCASTIF &&
+        if (CONFIG->SHCUPD_MCASTIF &&
             setsockopt(s, IPPROTO_IP, IP_MULTICAST_IF, &mreqn, sizeof(mreqn)) < 0) {
             fail("{setsockopt: IP_MULTICAST_IF}");
         }
 
-        if (OPTIONS.SHCUPD_MCASTTTL) {
+        if (CONFIG->SHCUPD_MCASTTTL) {
              unsigned char ttl;
 
-             ttl = (unsigned char)atoi(OPTIONS.SHCUPD_MCASTTTL);
+             ttl = (unsigned char)atoi(CONFIG->SHCUPD_MCASTTTL);
              if (setsockopt(s, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0) {
                  fail("{setsockopt: IP_MULTICAST_TTL}");
              }
@@ -505,17 +441,17 @@ static int create_shcupd_socket() {
         memcpy(&mreq.ipv6mr_multiaddr, &((struct sockaddr_in6 *)ai->ai_addr)->sin6_addr,
                                        sizeof(mreq.ipv6mr_multiaddr));
 
-        if (OPTIONS.SHCUPD_MCASTIF) {
-            if (isalpha(*OPTIONS.SHCUPD_MCASTIF)) { /* appears to be an iface name */
+        if (CONFIG->SHCUPD_MCASTIF) {
+            if (isalpha(*CONFIG->SHCUPD_MCASTIF)) { /* appears to be an iface name */
                 struct ifreq ifr;
 
                 memset(&ifr, 0, sizeof(ifr));
-                if (strlen(OPTIONS.SHCUPD_MCASTIF) > IFNAMSIZ) {
-                    ERR("Error iface name is too long [%s]\n",OPTIONS.SHCUPD_MCASTIF);
+                if (strlen(CONFIG->SHCUPD_MCASTIF) > IFNAMSIZ) {
+                    ERR("Error iface name is too long [%s]\n",CONFIG->SHCUPD_MCASTIF);
                     exit(1);
                 }
 
-                memcpy(ifr.ifr_name, OPTIONS.SHCUPD_MCASTIF, strlen(OPTIONS.SHCUPD_MCASTIF));
+                memcpy(ifr.ifr_name, CONFIG->SHCUPD_MCASTIF, strlen(CONFIG->SHCUPD_MCASTIF));
                 if (ioctl(s, SIOCGIFINDEX, &ifr)) {
                     fail("{ioctl: SIOCGIFINDEX}");
                 }
@@ -523,7 +459,7 @@ static int create_shcupd_socket() {
                 mreq.ipv6mr_interface = ifr.ifr_ifindex;
             }
             else { /* option appears to be an iface index */
-                mreq.ipv6mr_interface = atoi(OPTIONS.SHCUPD_MCASTIF);
+                mreq.ipv6mr_interface = atoi(CONFIG->SHCUPD_MCASTIF);
             }
         }
 
@@ -547,10 +483,10 @@ static int create_shcupd_socket() {
             fail("{setsockopt: IPV6_MULTICAST_IF}");
         }
 
-        if (OPTIONS.SHCUPD_MCASTTTL) {
+        if (CONFIG->SHCUPD_MCASTTTL) {
             int hops;
 
-            hops = atoi(OPTIONS.SHCUPD_MCASTTTL);
+            hops = atoi(CONFIG->SHCUPD_MCASTTTL);
             if (setsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &hops, sizeof(hops)) < 0) {
                 fail("{setsockopt: IPV6_MULTICAST_HOPS}");
             }
@@ -589,7 +525,7 @@ RSA *load_rsa_privatekey(SSL_CTX *ctx, const char *file) {
 /* Init library and load specified certificate.
  * Establishes a SSL_ctx, to act as a template for
  * each connection */
-static SSL_CTX * init_openssl() {
+SSL_CTX * init_openssl() {
     SSL_library_init();
     SSL_load_error_strings();
     SSL_CTX *ctx = NULL;
@@ -598,12 +534,12 @@ static SSL_CTX * init_openssl() {
     long ssloptions = SSL_OP_NO_SSLv2 | SSL_OP_ALL | 
             SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
 
-    if (OPTIONS.ETYPE == ENC_TLS)
+    if (CONFIG->ETYPE == ENC_TLS)
         ctx = SSL_CTX_new(TLSv1_server_method());
-    else if (OPTIONS.ETYPE == ENC_SSL)
+    else if (CONFIG->ETYPE == ENC_SSL)
         ctx = SSL_CTX_new(SSLv23_server_method());
     else
-        assert(OPTIONS.ETYPE == ENC_TLS || OPTIONS.ETYPE == ENC_SSL);
+        assert(CONFIG->ETYPE == ENC_TLS || CONFIG->ETYPE == ENC_SSL);
 
 #ifdef SSL_OP_NO_COMPRESSION
     ssloptions |= SSL_OP_NO_COMPRESSION;
@@ -612,12 +548,12 @@ static SSL_CTX * init_openssl() {
     SSL_CTX_set_options(ctx, ssloptions);
     SSL_CTX_set_info_callback(ctx, info_callback);
 
-    if (SSL_CTX_use_certificate_chain_file(ctx, OPTIONS.CERT_FILE) <= 0) {
+    if (SSL_CTX_use_certificate_chain_file(ctx, CONFIG->CERT_FILE) <= 0) {
         ERR_print_errors_fp(stderr);
         exit(1);
     }
 
-    rsa = load_rsa_privatekey(ctx, OPTIONS.CERT_FILE);
+    rsa = load_rsa_privatekey(ctx, CONFIG->CERT_FILE);
     if(!rsa) {
        ERR("Error loading rsa private key\n");
        exit(1);
@@ -629,16 +565,16 @@ static SSL_CTX * init_openssl() {
     }
 
 #ifndef OPENSSL_NO_DH
-    init_dh(ctx, OPTIONS.CERT_FILE);
+    init_dh(ctx, CONFIG->CERT_FILE);
 #endif /* OPENSSL_NO_DH */
 
-    if (OPTIONS.ENGINE) {
+    if (CONFIG->ENGINE) {
         ENGINE *e = NULL;
         ENGINE_load_builtin_engines();
-        if (!strcmp(OPTIONS.ENGINE, "auto"))
+        if (!strcmp(CONFIG->ENGINE, "auto"))
             ENGINE_register_all_complete();
         else {
-            if ((e = ENGINE_by_id(OPTIONS.ENGINE)) == NULL ||
+            if ((e = ENGINE_by_id(CONFIG->ENGINE)) == NULL ||
                 !ENGINE_init(e) ||
                 !ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
                 ERR_print_errors_fp(stderr);
@@ -650,20 +586,20 @@ static SSL_CTX * init_openssl() {
         }
     }
 
-    if (OPTIONS.CIPHER_SUITE)
-        if (SSL_CTX_set_cipher_list(ctx, OPTIONS.CIPHER_SUITE) != 1)
+    if (CONFIG->CIPHER_SUITE)
+        if (SSL_CTX_set_cipher_list(ctx, CONFIG->CIPHER_SUITE) != 1)
             ERR_print_errors_fp(stderr);
 
-    if (OPTIONS.PREFER_SERVER_CIPHERS)
+    if (CONFIG->PREFER_SERVER_CIPHERS)
         SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
 
 #ifdef USE_SHARED_CACHE
-    if (OPTIONS.SHARED_CACHE) {
-        if (shared_context_init(ctx, OPTIONS.SHARED_CACHE) < 0) {
+    if (CONFIG->SHARED_CACHE) {
+        if (shared_context_init(ctx, CONFIG->SHARED_CACHE) < 0) {
             ERR("Unable to alloc memory for shared cache.\n");
             exit(1);
         }
-	if (OPTIONS.SHCUPD_PORT) {
+	if (CONFIG->SHCUPD_PORT) {
             if (compute_secret(rsa, shared_secret) < 0) {
                 ERR("Unable to compute shared secret.\n");
                 exit(1);
@@ -719,7 +655,7 @@ static int create_main_socket() {
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
-    const int gai_err = getaddrinfo(OPTIONS.FRONT_IP, OPTIONS.FRONT_PORT,
+    const int gai_err = getaddrinfo(CONFIG->FRONT_IP, CONFIG->FRONT_PORT,
                                     &hints, &ai);
     if (gai_err != 0) {
         ERR("{getaddrinfo}: [%s]\n", gai_strerror(gai_err));
@@ -750,7 +686,7 @@ static int create_main_socket() {
     prepare_proxy_line(ai->ai_addr);
 
     freeaddrinfo(ai);
-    listen(s, OPTIONS.BACKLOG);
+    listen(s, CONFIG->BACKLOG);
 
     return s;
 }
@@ -915,7 +851,7 @@ static void handle_connect(struct ev_loop *loop, ev_io *w, int revents) {
         ev_io_init(&ps->ev_w_down, back_write, ps->fd_down, EV_WRITE);
         start_handshake(ps, SSL_ERROR_WANT_READ); /* for client-first handshake */
         ev_io_start(loop, &ps->ev_r_down);
-        if (OPTIONS.WRITE_PROXY_LINE) {
+        if (CONFIG->WRITE_PROXY_LINE) {
             char *ring_pnt = ringbuffer_write_ptr(&ps->ring_down);
             assert(ps->remote_ip.ss_family == AF_INET ||
 		   ps->remote_ip.ss_family == AF_INET6);
@@ -941,7 +877,7 @@ static void handle_connect(struct ev_loop *loop, ev_io *w, int revents) {
             ringbuffer_write_append(&ps->ring_down, written);
             ev_io_start(loop, &ps->ev_w_down);
         }
-        else if (OPTIONS.WRITE_IP_OCTET) {
+        else if (CONFIG->WRITE_IP_OCTET) {
             char *ring_pnt = ringbuffer_write_ptr(&ps->ring_down);
             assert(ps->remote_ip.ss_family == AF_INET ||
                    ps->remote_ip.ss_family == AF_INET6);
@@ -1264,331 +1200,17 @@ static void handle_connections() {
     exit(1);
 }
 
-
-/* Print usage w/error message and exit failure */
-static void usage_fail(const char *prog, const char *msg) {
-    if (msg)
-        fprintf(stderr, "%s: %s\n", prog, msg);
-    fprintf(stderr, "usage: %s [OPTION] PEM\n", prog);
-
-    fprintf(stderr,
-"Encryption Methods:\n"
-"  --tls                    TLSv1 (default)\n"
-"  --ssl                    SSLv3 (implies no TLSv1)\n"
-"  -c CIPHER_SUITE          set allowed ciphers (default is OpenSSL defaults)\n"
-"  -e ENGINE                set OpenSSL engine\n"
-"  -O                       prefer server cipher order\n"
-"\n"
-"Socket:\n"
-"  -b HOST,PORT             backend [connect] (default is \"127.0.0.1,8000\")\n"
-"  -f HOST,PORT             frontend [bind] (default is \"*,8443\")\n"
-#ifdef USE_SHARED_CACHE
-"  -U HOST,PORT             accept cache updates on udp (default disabled, needs shared cache enabled)\n"
-"  -P HOST[,PORT]           send cache updates to peer (multiple option, needs updates enabled)\n"
-"  -M IFACE[,TTL]           force iface and ttl to receive and send multicast updates\n"
-#endif
-"\n"
-"Performance:\n"
-"  -n CORES                 number of worker processes (default is 1)\n"
-"  -B BACKLOG               set listen backlog size (default is 100)\n"
-"  -k SECS                  Change default tcp keepalive on client socket\n"
-#ifdef USE_SHARED_CACHE
-"  -C SHARED_CACHE          set shared cache size in sessions (default no shared cache)\n"
-#endif
-"\n"
-"Security:\n"
-"  -r PATH                  chroot\n"
-"  -u USERNAME              set gid/uid after binding the socket\n"
-"\n"
-"Logging:\n"
-"  -q                       be quiet; emit only error messages\n"
-"  -s                       send log message to syslog in addition to stderr/stdout\n"
-"\n"
-"Special:\n"
-"  --daemon                 fork into background and become a daemon\n"
-"  --write-ip               write 1 octet with the IP family followed by the IP\n"
-"                           address in 4 (IPv4) or 16 (IPv6) octets little-endian\n"
-"                           to backend before the actual data\n"
-"  --write-proxy            write HaProxy's PROXY (IPv4 or IPv6) protocol line\n" 
-"                           before actual data\n"
-);
-    exit(1);
-}
-
-
-static void parse_host_and_port(const char *prog, const char *name, char *inp, int wildcard_okay, const char **ip, const char **port) {
-    char buf[150];
-    char *sp;
-
-    if (strlen(inp) >= sizeof buf) {
-        snprintf(buf, sizeof buf, "invalid option for %s HOST,PORT\n", name);
-        usage_fail(prog, buf);
-    }
-
-    sp = strchr(inp, ',');
-    if (!sp) {
-        snprintf(buf, sizeof buf, "invalid option for %s HOST,PORT\n", name);
-        usage_fail(prog, buf);
-    }
-
-    if (!strncmp(inp, "*", sp - inp)) {
-        if (!wildcard_okay) {
-            snprintf(buf, sizeof buf, "wildcard host specification invalid for %s\n", name);
-            usage_fail(prog, buf);
-        }
-        *ip = NULL;
-    }
-    else {
-        *sp = 0;
-        *ip = inp;
-    }
-    *port = sp + 1;
-}
-
-#ifdef USE_SHARED_CACHE
-/* Parse mcast and ttl options */
-static void parse_mcast_iface_and_ttl(const char *prog, const char *name, char *inp, const char **iface, const char **ttl) {
-    char buf[150];
-    char *sp;
-
-    if (strlen(inp) >= sizeof buf) {
-        snprintf(buf, sizeof buf, "invalid option for %s IFACE[,TTL]\n", name);
-        usage_fail(prog, buf);
-    }
-
-    sp = strchr(inp, ',');
-    if (!sp) {
-        if (!strcmp(inp, "*"))
-            *iface = NULL;
-        else
-            *iface = inp;
-        *ttl = NULL;
-        return;
-    }
-    else if (!strncmp(inp, "*", sp - inp)) {
-        *iface = NULL;
-    }
-    else {
-        *sp = 0;
-        *iface = inp;
-    }
-    *ttl = sp + 1;
-}
-
-static void parse_peer(const char *prog, const char *name, char *inp, const char **ip, const char **port) {
-    char buf[150];
-    char *sp;
-
-    if (strlen(inp) >= sizeof buf) {
-        snprintf(buf, sizeof buf, "invalid option for %s HOST[,PORT]\n", name);
-        usage_fail(prog, buf);
-    }
-
-    sp = strchr(inp, ',');
-    if (!sp) {
-        if (!strcmp(inp, "*")) {
-            snprintf(buf, sizeof buf, "wildcard host specification invalid for %s\n", name);
-            usage_fail(prog, buf);
-        }
-        else
-            *ip = inp;
-        *port = NULL;
-        return;
-    }
-    else if (!strncmp(inp, "*", sp - inp)) {
-        snprintf(buf, sizeof buf, "wildcard host specification invalid for %s\n", name);
-        usage_fail(prog, buf);
-    }
-    else {
-        *sp = 0;
-        *ip = inp;
-    }
-    *port = sp + 1;
-}
-
-/* Add shcupd peer to options */
-static void parse_peers(const char *prog, const char *name, char *inp) {
-    int i;
-
-    for (i = 0 ; i < MAX_SHCUPD_PEERS; i++) {
-         if (!OPTIONS.SHCUPD_PEERS[i].ip) {
-             parse_peer(prog, name, inp, &(OPTIONS.SHCUPD_PEERS[i].ip), &(OPTIONS.SHCUPD_PEERS[i].port));
-             memset(&(OPTIONS.SHCUPD_PEERS[i+1]), 0, sizeof(shcupd_peer_opt));
-             break;
-         }
-    }
-    if (i == MAX_SHCUPD_PEERS ) {
-        ERR("Maximum %s peers reach (%d)\n", name, MAX_SHCUPD_PEERS);
-        exit(1);
-    }
-}
-
-#endif /* USE_SHARED_CACHE */
-
-/* Handle command line arguments modifying behavior */
-static void parse_cli(int argc, char **argv) {
-    const char *prog = argv[0];
-
-    static int tls = 0, ssl = 0;
-    int c;
-    struct passwd* passwd;
-
-    static struct option long_options[] =
-    {
-        {"tls", 0, &tls, 1},
-        {"ssl", 0, &ssl, 1},
-        {"write-ip", 0, &OPTIONS.WRITE_IP_OCTET, 1},
-        {"write-proxy", 0, &OPTIONS.WRITE_PROXY_LINE, 1},
-        {"daemon", 0, &OPTIONS.DAEMONIZE, 1},
-        {0, 0, 0, 0}
-    };
-
-    while (1) {
-        int option_index = 0;
-        c = getopt_long(argc, argv, "hf:b:n:c:e:Ou:r:B:C:k:qsU:P:M:",
-                long_options, &option_index);
-
-        if (c == -1)
-            break;
-
-        switch (c) {
-
-        case 0:
-            break;
-
-        case 'n':
-            errno = 0;
-            OPTIONS.NCORES = strtol(optarg, NULL, 10);
-            if ((errno == ERANGE &&
-                (OPTIONS.NCORES == LONG_MAX || OPTIONS.NCORES == LONG_MIN)) ||
-                OPTIONS.NCORES < 1 || OPTIONS.NCORES > 128) {
-                usage_fail(prog, "invalid option for -n CORES; please provide an integer between 1 and 128\n");
-            }
-            break;
-
-        case 'b':
-            parse_host_and_port(prog, "-b", optarg, 0, &(OPTIONS.BACK_IP), &(OPTIONS.BACK_PORT));
-            break;
-
-        case 'f':
-            parse_host_and_port(prog, "-f", optarg, 1, &(OPTIONS.FRONT_IP), &(OPTIONS.FRONT_PORT));
-            break;
-            
-        case 'c':
-            OPTIONS.CIPHER_SUITE = optarg;
-            break;
-
-        case 'e':
-            OPTIONS.ENGINE = optarg;
-            break;
-
-        case 'O':
-            OPTIONS.PREFER_SERVER_CIPHERS = 1;
-            break;
-
-        case 'u':
-            passwd = getpwnam(optarg);
-            if (!passwd) {
-                if (errno)
-                    fail("getpwnam failed");
-                else
-                    ERR("user not found: %s\n", optarg);
-                exit(1);
-            }
-            OPTIONS.UID = passwd->pw_uid;
-            OPTIONS.GID = passwd->pw_gid;
-            break;
-
-        case 'r':
-            if (optarg && optarg[0] == '/')
-                OPTIONS.CHROOT = optarg;
-            else {
-                ERR("chroot must be absolute path: \"%s\"\n", optarg);
-                exit(1);
-            }
-            break;
-
-        case 'B':
-            OPTIONS.BACKLOG = atoi(optarg);
-            if ( OPTIONS.BACKLOG <= 0 ) {
-                ERR("listen backlog can not be set to %d\n", OPTIONS.BACKLOG);
-                exit(1);
-            }
-            break;
-
-#ifdef USE_SHARED_CACHE
-        case 'C':
-            OPTIONS.SHARED_CACHE = atoi(optarg);
-            if ( OPTIONS.SHARED_CACHE < 0 ) {
-                ERR("shared cache size can not be set to %d\n", OPTIONS.SHARED_CACHE);
-                exit(1);
-            }
-            break;
-
-        case 'U':
-            parse_host_and_port(prog, "-U", optarg, 1, &(OPTIONS.SHCUPD_IP), &(OPTIONS.SHCUPD_PORT));
-            break;
-
-        case 'P':
-            parse_peers(prog, "-P", optarg);
-            break;
-
-        case 'M':
-            parse_mcast_iface_and_ttl(prog, "-M", optarg, &(OPTIONS.SHCUPD_MCASTIF), &(OPTIONS.SHCUPD_MCASTTTL));
-            break;
-#endif
-
-        case 'q':
-            OPTIONS.QUIET = 1;
-            break;
-        
-        case 's':
-            OPTIONS.SYSLOG = 1;
-            break;
-
-        case 'k':
-            OPTIONS.TCP_KEEPALIVE_TIME = atoi(optarg);
-            break;
-
-        default:
-            usage_fail(prog, NULL);
-        }
-    }
-
-    /* Post-processing */
-    if (tls && ssl)
-        usage_fail(prog, "Cannot specify both --tls and --ssl");
-
-    if (ssl)
-        OPTIONS.ETYPE = ENC_SSL; // implied.. else, TLS
-
-    if (OPTIONS.WRITE_IP_OCTET && OPTIONS.WRITE_PROXY_LINE)
-        usage_fail(prog, "Cannot specify both --write-ip and --write-proxy; pick one!");
-
-    argc -= optind;
-    argv += optind;
-
-    if (argc != 1)
-        usage_fail(prog, "exactly one argument is required: path to PEM file with cert/key");
-
-    OPTIONS.CERT_FILE = argv[0];
-
-    /* parent process can create new children */
-    create_workers = 1;
-}
-
-
 void change_root() {
-    if (chroot(OPTIONS.CHROOT) == -1)
+    if (chroot(CONFIG->CHROOT) == -1)
         fail("chroot");
     if (chdir("/"))
         fail("chdir");
 }
 
 void drop_privileges() {
-    if (setgid(OPTIONS.GID))
+    if (setgid(CONFIG->GID))
         fail("setgid failed");
-    if (setuid(OPTIONS.UID))
+    if (setuid(CONFIG->UID))
         fail("setuid failed");
 }
 
@@ -1600,7 +1222,7 @@ void init_globals() {
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags = 0;
-    const int gai_err = getaddrinfo(OPTIONS.BACK_IP, OPTIONS.BACK_PORT,
+    const int gai_err = getaddrinfo(CONFIG->BACK_IP, CONFIG->BACK_PORT,
                                     &hints, &backaddr);
     if (gai_err != 0) {
         ERR("{getaddrinfo}: [%s]", gai_strerror(gai_err));
@@ -1608,9 +1230,9 @@ void init_globals() {
     }
 
 #ifdef USE_SHARED_CACHE
-    if (OPTIONS.SHARED_CACHE) {
+    if (CONFIG->SHARED_CACHE) {
         /* cache update peers addresses */
-        shcupd_peer_opt *spo = OPTIONS.SHCUPD_PEERS;
+        shcupd_peer_opt *spo = CONFIG->SHCUPD_PEERS;
         struct addrinfo **pai = shcupd_peers;
 
         while (spo->ip) {
@@ -1619,7 +1241,7 @@ void init_globals() {
             hints.ai_socktype = SOCK_DGRAM;
             hints.ai_flags = 0;
             const int gai_err = getaddrinfo(spo->ip,
-                                spo->port ? spo->port : OPTIONS.SHCUPD_PORT, &hints, pai);
+                                spo->port ? spo->port : CONFIG->SHCUPD_PORT, &hints, pai);
             if (gai_err != 0) {
                 ERR("{getaddrinfo}: [%s]", gai_strerror(gai_err));
                 exit(1);
@@ -1630,10 +1252,10 @@ void init_globals() {
     }
 #endif
     /* child_pids */
-    if ((child_pids = calloc(OPTIONS.NCORES, sizeof(pid_t))) == NULL)
+    if ((child_pids = calloc(CONFIG->NCORES, sizeof(pid_t))) == NULL)
         fail("calloc");
 
-    if (OPTIONS.SYSLOG)
+    if (CONFIG->SYSLOG)
         openlog("stud", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_DAEMON);
 }
 
@@ -1665,7 +1287,7 @@ void replace_child_with_pid(pid_t pid) {
     int i;
 
     /* find old child's slot and put a new child there */ 
-    for (i = 0; i < OPTIONS.NCORES; i++) {
+    for (i = 0; i < CONFIG->NCORES; i++) {
         if (child_pids[i] == pid) {
             start_children(i, 1);
             return;
@@ -1684,7 +1306,7 @@ static void do_wait(int __attribute__ ((unused)) signo) {
     if (pid == -1) {
         if (errno == ECHILD) {
             ERR("{core} All children have exited! Restarting...\n");
-            start_children(0, OPTIONS.NCORES);
+            start_children(0, CONFIG->NCORES);
         }
         else if (errno == EINTR) {
             ERR("{core} Interrupted wait\n");
@@ -1715,7 +1337,7 @@ static void sigh_terminate (int __attribute__ ((unused)) signo) {
 
         /* kill all children */
         int i;
-        for (i = 0; i < OPTIONS.NCORES; i++) {
+        for (i = 0; i < CONFIG->NCORES; i++) {
             /* LOG("Stopping worker pid %d.\n", child_pids[i]); */
             if (child_pids[i] > 1 && kill(child_pids[i], SIGTERM) != 0) {
                 ERR("{core} Unable to send SIGTERM to worker pid %d: %s\n", child_pids[i], strerror(errno));
@@ -1835,7 +1457,13 @@ void openssl_check_version() {
 /* Process command line args, create the bound socket,
  * spawn child (worker) processes, and respawn if any die */
 int main(int argc, char **argv) {
-    parse_cli(argc, argv);
+    // initialize configuration
+    CONFIG = config_new();
+    
+    // parse command line
+    config_parse_cli(argc, argv, CONFIG);
+    
+    create_workers = 1;
 
     openssl_check_version();
 
@@ -1846,7 +1474,7 @@ int main(int argc, char **argv) {
     listener_socket = create_main_socket();
 
 #ifdef USE_SHARED_CACHE
-    if (OPTIONS.SHCUPD_PORT) {
+    if (CONFIG->SHCUPD_PORT) {
         /* create socket to send(children) and
                receive(parent) cache updates */
     	shcupd_socket = create_shcupd_socket();
@@ -1856,17 +1484,17 @@ int main(int argc, char **argv) {
     /* load certificate, pass to handle_connections */
     ssl_ctx = init_openssl();
 
-    if (OPTIONS.CHROOT && OPTIONS.CHROOT[0])
+    if (CONFIG->CHROOT && CONFIG->CHROOT[0])
         change_root();
 
-    if (OPTIONS.UID || OPTIONS.GID)
+    if (CONFIG->UID || CONFIG->GID)
         drop_privileges();
 
     /* should we daemonize ?*/
-    if (OPTIONS.DAEMONIZE) {
+    if (CONFIG->DAEMONIZE) {
         /* disable logging to stderr */
-        OPTIONS.QUIET = 1;
-        OPTIONS.SYSLOG = 1;
+        CONFIG->QUIET = 1;
+        CONFIG->SYSLOG = 1;
 
         /* become a daemon */
         daemonize();
@@ -1874,10 +1502,10 @@ int main(int argc, char **argv) {
 
     master_pid = getpid();
 
-    start_children(0, OPTIONS.NCORES);
+    start_children(0, CONFIG->NCORES);
 
 #ifdef USE_SHARED_CACHE
-    if (OPTIONS.SHCUPD_PORT) {
+    if (CONFIG->SHCUPD_PORT) {
         /* start event loop to receive cache updates */
 
         loop = ev_default_loop(EVFLAG_AUTO);
@@ -1894,6 +1522,6 @@ int main(int argc, char **argv) {
          * Parent will be woken up if a signal arrives */
         pause();
     }
-
+    
     exit(0); /* just a formality; we never get here */
 }

--- a/version.h
+++ b/version.h
@@ -1,0 +1,1 @@
+#define STUD_VERSION "0.3-dev"


### PR DESCRIPTION
This patch adds the following functionality:
- configuration file loading
- default configuration printout
- printing of loaded configuration
- configuration testing
- nicer --help message
- version printing
- addresses have new syntax: [HOST]:PORT
- HOST,PORT arguments are still supported

Stud can still be built without configuration file support by
providing NO_CONFIG_FILE=1 argument to make
