### PR TITLE
Added --read-proxy option to require reading the HAProxy protocol line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,13 @@ Detail about the entire set of options can be found by invoking `stud -h`:
                                  address in 4 (IPv4) or 16 (IPv6) octets little-endian
                                  to backend before the actual data
                                  (Default: off)
-          --write-proxy          Write HaProxy's PROXY (IPv4 or IPv6) protocol line
-                                 before actual data
+          --write-proxy          Write HAProxy's PROXY (IPv4 or IPv6) protocol line
+                                 to the backend before actual data
+                                 (Default: off)
+          --read-proxy           Read HAProxy's PROXY (IPv4 or IPv6) protocol line
+                                 before actual data.  This address will be sent to
+                                 the backend if one of --write-ip or --write-proxy
+                                 is specified.
                                  (Default: off)
 
       -t  --test                 Test configuration and exit

--- a/configuration.c
+++ b/configuration.c
@@ -42,6 +42,7 @@
 #define CFG_DAEMON "daemon"
 #define CFG_WRITE_IP "write-ip"
 #define CFG_WRITE_PROXY "write-proxy"
+#define CFG_READ_PROXY "read-proxy"
 #define CFG_PEM_FILE "pem-file"
 
 #ifdef USE_SHARED_CACHE
@@ -110,6 +111,7 @@ stud_config * config_new (void) {
   r->ETYPE              = ENC_TLS;
   r->WRITE_IP_OCTET     = 0;
   r->WRITE_PROXY_LINE   = 0;
+  r->READ_PROXY_LINE    = 0;
   r->CHROOT             = NULL;
   r->UID                = 0;
   r->GID                = 0;
@@ -629,6 +631,9 @@ void config_param_validate (char *k, char *v, stud_config *cfg, char *file, int 
   else if (strcmp(k, CFG_WRITE_PROXY) == 0) {
     r = config_param_val_bool(v, &cfg->WRITE_PROXY_LINE);
   }
+  else if (strcmp(k, CFG_READ_PROXY) == 0) {
+    r = config_param_val_bool(v, &cfg->READ_PROXY_LINE);
+  }
   else if (strcmp(k, CFG_PEM_FILE) == 0) {
     if (v != NULL && strlen(v) > 0) {
       if (stat(v, &st) != 0) {
@@ -813,9 +818,14 @@ void config_print_usage_fd (char *prog, stud_config *cfg, FILE *out) {
   fprintf(out, "                             address in 4 (IPv4) or 16 (IPv6) octets little-endian\n");
   fprintf(out, "                             to backend before the actual data\n");
   fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->WRITE_IP_OCTET));
-  fprintf(out, "      --write-proxy          Write HaProxy's PROXY (IPv4 or IPv6) protocol line\n" );
-  fprintf(out, "                             before actual data\n");
+  fprintf(out, "      --write-proxy          Write HAProxy's PROXY (IPv4 or IPv6) protocol line\n" );
+  fprintf(out, "                             to the backend before actual data\n");
   fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->WRITE_PROXY_LINE));
+  fprintf(out, "      --read-proxy           Read HAProxy's PROXY (IPv4 or IPv6) protocol line\n" );
+  fprintf(out, "                             before actual data.  This address will be sent to\n");
+  fprintf(out, "                             the backend if one of --write-ip or --write-proxy\n");
+  fprintf(out, "                             is specified.\n");
+  fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->READ_PROXY_LINE));
   fprintf(out, "\n");
   fprintf(out, "  -t  --test                 Test configuration and exit\n");
   fprintf(out, "  -V  --version              Print program version and exit\n");
@@ -982,7 +992,7 @@ void config_print_default (FILE *fd, stud_config *cfg) {
   fprintf(fd, FMT_STR, CFG_WRITE_IP, config_disp_bool(cfg->WRITE_IP_OCTET));
   fprintf(fd, "\n");
 
-  fprintf(fd, "# Report client address using SENDPROXY protocol, see\n");
+  fprintf(fd, "# Report client address using HAProxy PROXY protocol line, see\n");
   fprintf(fd, "# http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt\n");
   fprintf(fd, "# for details.\n");
   fprintf(fd, "#\n");
@@ -990,6 +1000,15 @@ void config_print_default (FILE *fd, stud_config *cfg) {
   fprintf(fd, "#\n");
   fprintf(fd, "# type: boolean\n");
   fprintf(fd, FMT_STR, CFG_WRITE_PROXY, config_disp_bool(cfg->WRITE_PROXY_LINE));
+  fprintf(fd, "\n");
+
+  fprintf(fd, "# Read client address using HAProxy PROXY protocol line, see\n");
+  fprintf(fd, "# http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt\n");
+  fprintf(fd, "# for details. This address will be reported to the backend\n");
+  fprintf(fd, "# if one of %s or %s is specified.\n", CFG_WRITE_IP, CFG_WRITE_PROXY);
+  fprintf(fd, "#\n");
+  fprintf(fd, "# type: boolean\n");
+  fprintf(fd, FMT_STR, CFG_READ_PROXY, config_disp_bool(cfg->READ_PROXY_LINE));
   fprintf(fd, "\n");
 
   fprintf(fd, "# EOF\n");
@@ -1035,6 +1054,7 @@ void config_parse_cli(int argc, char **argv, stud_config *cfg) {
     { CFG_DAEMON, 0, &cfg->DAEMONIZE, 1 },
     { CFG_WRITE_IP, 0, &cfg->WRITE_IP_OCTET, 1 },
     { CFG_WRITE_PROXY, 0, &cfg->WRITE_PROXY_LINE, 1 },
+    { CFG_READ_PROXY, 0, &cfg->READ_PROXY_LINE, 1 },
  
     { "test", 0, NULL, 't' },
     { "version", 0, NULL, 'V' },

--- a/configuration.h
+++ b/configuration.h
@@ -31,6 +31,7 @@ struct __stud_config {
     ENC_TYPE ETYPE;
     int WRITE_IP_OCTET;
     int WRITE_PROXY_LINE;
+    int READ_PROXY_LINE;
     char *CHROOT;
     uid_t UID;
     gid_t GID;

--- a/init.stud
+++ b/init.stud
@@ -97,13 +97,21 @@ CLIENT_TCP_KEEPALIVE_SEC=""
 # log to syslog?
 SYSLOG="1"
 
-# Enable write-ip?
+# Write 1 octet with the IP family followed by the IP
+# address in 4 (IPv4) or 16 (IPv6) octets little-endian
+# to backend before the actual data
 WRITE_IP="0"
 
-# Enable SENDPROXY protocol; see
+# Enable writing HAProxy protocol line to the backend before
+# actual data, see
 # http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt
 # for additional info
 WRITE_PROXY="0"
+
+# Enable reading HAProxy protocol line before actual data.
+# This address will be sent to the backend if one of
+# WRITE_IP or WRITE_PROXY is specified.
+READ_PROXY="0"
 
 # Alternative OpenSSL library dir
 # Use this if you'd like to run stud with different
@@ -237,6 +245,7 @@ _real_single_instance_start() {
 
   test "${WRITE_IP}" = "1" && opts="${opts} --write-ip"
   test "${WRITE_PROXY}" = "1" && opts="${opts} --write-proxy"
+  test "${READ_PROXY}" = "1" && opts="${opts} --read-proxy"
 
   if [ ! -z "${CERT_FILE}" ] && [ -f "${CERT_FILE}" ] && [ -r "${CERT_FILE}" ]; then
     opts="${opts} ${CERT_FILE}"


### PR DESCRIPTION
The read address is then passed to the backend server if --write-proxy or --write-ip is specified.
This can be useful if you use HAProxy as your load balancer (in TCP mode) and run stud distributed on each of your servers and want the original client IP address.
