### PR TITLE
Logging: make syslog facility configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Detail about the entire set of options can be found by invoking `stud -h`:
     LOGGING:
       -q  --quiet                Be quiet; emit only error messages
       -s  --syslog               Send log message to syslog in addition to stderr/stdout
+      --syslog-facility=FACILITY Syslog facility to use (Default: "daemon")
 
     OTHER OPTIONS:
           --daemon               Fork into background and become a daemon (Default: off)

--- a/configuration.h
+++ b/configuration.h
@@ -53,6 +53,7 @@ struct __stud_config {
 #endif
     int QUIET;
     int SYSLOG;
+    int SYSLOG_FACILITY;
     int TCP_KEEPALIVE_TIME;
     int DAEMONIZE;
     int PREFER_SERVER_CIPHERS;

--- a/stud.8
+++ b/stud.8
@@ -107,6 +107,9 @@ Send messages to syslog in addition to
 .Em stderr
 and
 .Em stdout .
+.It Fl -syslog-facility Ar facility
+Syslog facility to use. Default is
+.Ar daemon .
 .It Fl -write-ip
 Write 1 octet with the IP family followed by the IP address in 4
 (IPv4) or 16 (IPv6) octets little-endian to backend before the actual

--- a/stud.c
+++ b/stud.c
@@ -1262,7 +1262,7 @@ void init_globals() {
         fail("calloc");
 
     if (CONFIG->SYSLOG)
-        openlog("stud", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_DAEMON);
+        openlog("stud", LOG_CONS | LOG_PID | LOG_NDELAY, CONFIG->SYSLOG_FACILITY);
 }
 
 /* Forks COUNT children starting with START_INDEX.


### PR DESCRIPTION
Syslog facility can be changed from the default (daemon) using --syslog-facility command line switch or syslog-facility keyword in the configuration file.  Includes updates to documentation.
