### PR TITLE
Honor the ssl config file & command-line option

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -528,10 +528,10 @@ void config_param_validate (char *k, char *v, stud_config *cfg, char *file, int 
   struct stat st;
       
   if (strcmp(k, "tls") == 0) {
-    //cfg->ENC_TLS = 1;
+    cfg->ETYPE = ENC_TLS;
   }
   else if (strcmp(k, "ssl") == 0) {
-    //cfg->ENC_TLS = 0;
+    cfg->ETYPE = ENC_SSL;
   }
   else if (strcmp(k, CFG_CIPHERS) == 0) {
     if (v != NULL && strlen(v) > 0) {


### PR DESCRIPTION
Hello,

Thanks for making stud.  Some time around merging @bfg's config file change (which is otherwise awesome) it seems the "ssl" config directive wasn't working.  The --ssl command-line option also stopped working.

As you can see, the fix is trivial.  My company has been using this fix in production for a few weeks (plus my `smartos` branch which has some fixes that should also work for Solaris in general).

Without this fix, Safari using `wss://` cannot connect (something in the way the negotiation happens, I haven't been able to investigate it fully).

Cheers, and thanks in advance.

~stash
