### PR TITLE
create_back_socket() could leak the just-created FD if connect() returns an unexpected error

### DIFF
--- a/stud.c
+++ b/stud.c
@@ -720,7 +720,7 @@ static int create_back_socket() {
         return s;
 
     perror("{backend-connect}");
-
+    close(s);
     return -1;
 }
 


### PR DESCRIPTION
EAGAIN is not likely with TCP (you'd need a bad ulimit for exampel), but if nothing else, 
it's hard on the eyes.
