### PR TITLE
Append CFLAGS/LDFLAGS to any flags already set, so custom builds with no...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ PREFIX  = /usr/local
 BINDIR  = $(PREFIX)/bin
 MANDIR  = $(PREFIX)/share/man
 
-CFLAGS  = -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -D_GNU_SOURCE -I/usr/local/include
-LDFLAGS = -lssl -lcrypto -lev -L/usr/local/lib
+CFLAGS  += -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -D_GNU_SOURCE -I/usr/local/include
+LDFLAGS += -lssl -lcrypto -lev -L/usr/local/lib
 OBJS    = stud.o ringbuffer.o configuration.o
 
 all: realall


### PR DESCRIPTION
...n-standard include paths can work.
