### PR TITLE
Fix Client Mode memory Leak:

### DIFF
--- a/stud.c
+++ b/stud.c
@@ -608,8 +608,13 @@ SSL_CTX * init_openssl() {
     init_dh(ctx, CONFIG->CERT_FILE);
 #endif /* OPENSSL_NO_DH */
 
+    if (CONFIG->PMODE == SSL_CLIENT) {
+        /* Disable internal cache of openssl: session reuse cause memory leak
+           in SSL_SESS_CACHE_CLIENT mode */
+        SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
+    }
 #ifdef USE_SHARED_CACHE
-    if (CONFIG->SHARED_CACHE) {
+    else if (CONFIG->SHARED_CACHE) {
         if (shared_context_init(ctx, CONFIG->SHARED_CACHE) < 0) {
             ERR("Unable to alloc memory for shared cache.\n");
             exit(1);


### PR DESCRIPTION
Disable openssl internal cache in client mode to let application
manage reuse session.
