### PR TITLE
Provide link to stud Chef cookbook in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ To use DH with stud, you will need to add some bytes to your pem file:
 
 Be sure to set your cipher suite appropriately: -c DHE-RSA-AES256-SHA
 
+
+Deploying with Chef
+-------------------
+
+If you're using Chef for your server infrastructure, you may want to use the premade [stud cookbook](http://community.opscode.com/cookbooks/stud).
+
+It is maintained in its own [github repository](https://github.com/freerobby/chef-stud).
+
 Authors
 -------
 


### PR DESCRIPTION
I wrote a chef cookbook for building, configuring and deploying stud on production boxes. You can see it here: https://github.com/freerobby/chef-stud

This built this for shareaholic.com's deployment infrastructure, and thought it's worth mentioning in the Readme in case other folks need something similar.
