### PR TITLE
print error message(s) if parsing RSA private key fails

### DIFF
--- a/stud.c
+++ b/stud.c
@@ -549,6 +549,9 @@ RSA *load_rsa_privatekey(SSL_CTX *ctx, const char *file) {
 
     rsa = PEM_read_bio_RSAPrivateKey(bio, NULL,
           ctx->default_passwd_callback, ctx->default_passwd_callback_userdata);
+    if(!rsa) {
+        ERR_print_errors_fp(stderr);
+    }
     BIO_free(bio);
 
     return rsa;


### PR DESCRIPTION
`PEM_read_bio_RSAPrivateKey()` can fail under some conditions, so we should print out OpenSSL's error message(s) to help the user understand and resolve the issue.
