### PR TITLE
Add support to build for RHEL/CentOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ rpm:
 	sed -re s/GIT_VERSION/$(shell git describe)/ \
 		rhel/stud.spec > ${TMPDIR}/SPECS/stud.spec
 	rpmbuild --define "_topdir ${TMPDIR}" \
-		-bb ${TMPDIR}/SPECS/stud.spec
+		-bb ${TMPDIR}/SPECS/stud.spec $(if $(USE_SHARED_CACHE),--with cache,)
 	find ${TMPDIR}/RPMS/ -type f -name "*.rpm" -exec mv {} . \;
 
 .PHONY: all realall

--- a/rhel/stud.spec
+++ b/rhel/stud.spec
@@ -16,6 +16,9 @@
     %undefine post_tag
 %endif
 
+# Use --with cache to build the RPM with the USE_SHARED_CACHE feature
+%bcond_with cache
+
 Name:		stud
 Version:	%{version}
 Release:	%{?post_tag}%{!?post_tag:1}%{?dist}
@@ -36,15 +39,18 @@ thousands of connections efficiently on multicore machines.
 
 %prep
 %setup -q
-
+%if %{with cache}
+mkdir ebtree
+curl http://1wt.eu/tools/ebtree/ebtree-6.0.8.tar.gz | tar xzf - -C "ebtree" --strip 1
+%endif
 
 %build
-make %{?_smp_mflags}
+make %{?_smp_mflags} %{?_with_cache:USE_SHARED_CACHE=1}
 
 
 %install
 rm -rf %{buildroot}
-make install DESTDIR=%{buildroot} PREFIX=/usr
+make install DESTDIR=%{buildroot} PREFIX=/usr %{?_with_cache:USE_SHARED_CACHE=1}
 install -d %{buildroot}/etc/init.d
 install init.stud %{buildroot}/etc/init.d/stud
 


### PR DESCRIPTION
This adds a SPEC file to build an RPM and a make option to make building easier

```
make rpm
```

will build an RPM for the current platform

```
make rpm USE_SHARED_CACHE=1
```

will build the RPM with the shared cache feature.
