### PR TITLE
Fix TLS setting to use TLS 1.x (support TLS 1.1/1.2)

### DIFF
--- a/stud.c
+++ b/stud.c
@@ -598,16 +598,14 @@ SSL_CTX *make_ctx(const char *pemfile) {
 #endif
 
     if (CONFIG->ETYPE == ENC_TLS) {
-        ctx = SSL_CTX_new((CONFIG->PMODE == SSL_CLIENT) ?
-                TLSv1_client_method() : TLSv1_server_method());
-    } else if (CONFIG->ETYPE == ENC_SSL) {
-        ctx = SSL_CTX_new((CONFIG->PMODE == SSL_CLIENT) ?
-                SSLv23_client_method() : SSLv23_server_method());
-    } else {
+        ssloptions |= SSL_OP_NO_SSLv3;
+    } else if (CONFIG->ETYPE != ENC_SSL) {
         assert(CONFIG->ETYPE == ENC_TLS || CONFIG->ETYPE == ENC_SSL);
         return NULL; // Won't happen, but gcc was complaining
     }
 
+    ctx = SSL_CTX_new((CONFIG->PMODE == SSL_CLIENT) ?
+            SSLv23_client_method() : SSLv23_server_method());
     SSL_CTX_set_options(ctx, ssloptions);
     SSL_CTX_set_info_callback(ctx, info_callback);
 


### PR DESCRIPTION
When we run using "--tls" (default) we create the SSL context with a
TLSv1_*_method(), however, this _only_ supports TLS 1.0 connections. In
contrast, when we run with "--ssl" we use a SSLv23_*_method() which
allows all supported protocols. We block SSL 2.0 by passing in the
SSL_OP_NO_SSLv2 flag in SSL_CTX_set_options. This results in the
somewhat counterintuitive situation where the supported protocols are:
- --tls: TLS 1.0
- --ssl: SSL 3.0, TLS 1.0, TLS 1.1, TLS 1.2

This patch fixes the handling of "--tls" so that it supports TLS 1.x
while ensuring SSL 3.0 is blocked (SSL 2.0 is always blocked).

This all assumes an OpenSSL library capable of supports newer TLS
versions, otherwise, the above change will have no effect on stud's
behaviour (ie. --ssl supports SSL 3.0/TLS 1.0, --tls supports TLS 1.0).
