### PR TITLE
Close the back socket if initial connect() fails.

### DIFF
--- a/stud.c
+++ b/stud.c
@@ -421,6 +421,7 @@ static int create_back_socket() {
         return s;
 
     perror("{backend-connect}");
+    close(s);
 
     return -1;
 }


### PR DESCRIPTION
When connect() in create_back_socket() fails (in my case the range of ephemeral ports got exhausted), create_back_socket() returns (-1) without closing the socket file descriptor which leads to leaking file descriptors.
