### PR TITLE
fixes https://github.com/bumptech/stud/issues/133 allowing for compilati...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PREFIX  = /usr/local
 BINDIR  = $(PREFIX)/bin
 MANDIR  = $(PREFIX)/share/man
 
-CFLAGS  = -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -D_GNU_SOURCE -I/usr/local/include
+CFLAGS  = -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -D_GNU_SOURCE -I/usr/local/include -I/usr/include/libev
 LDFLAGS = -lssl -lcrypto -lev -L/usr/local/lib
 OBJS    = stud.o ringbuffer.o configuration.o
 


### PR DESCRIPTION
...on on redhat derivatives that put libev in its own subdir. does not affect compilation on debian derivatives.
