### PR TITLE
Properly handle data queued in the SSL layer

### DIFF
--- a/stud.c
+++ b/stud.c
@@ -1230,6 +1230,9 @@ static void ssl_read(struct ev_loop *loop, ev_io *w, int revents) {
     char * buf = ringbuffer_write_ptr(&ps->ring_ssl2clear);
     t = SSL_read(ps->ssl, buf, RING_DATA_LEN);
 
+    if (SSL_pending(ps->ssl))
+        ev_feed_event(loop, w, EV_READ);
+
     /* Fix CVE-2009-3555. Disable reneg if started by client. */
     if (ps->renegotiation) {
         shutdown_proxy(ps, SHUTDOWN_SSL);


### PR DESCRIPTION
If, after an SSL_read operation, there is still data pending in
the SSL layer (such as the remainder of a TLS record), we need
to simulate an EV_READ event on the watcher. OpenSSL won't attempt
to read the data from the underlying socket until this data is
consumed. Since there is no new activity on the socket, libev will
not trigger a new EV_READ notification.

This just happened to work with the large () buffers passed to
SSL_read from the ringbuffer. However, when adjusting these buffers,
it becomes increasingly likely to deadlock a socket by leaving
this pending data in the OpenSSL buffers.